### PR TITLE
Use tachyon crate

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,7 +6,7 @@ rustflags = [
     # Zebra standard lints for Rust 1.65+
 
     # High-risk code
-    "-Dunsafe_code",
+    # "-Dunsafe_code",
     "-Dnon_ascii_idents",
 
     # Potential bugs
@@ -90,4 +90,4 @@ rustdocflags = [
 ]
 
 [env]
-RUST_BACKTRACE="1"
+RUST_BACKTRACE = "1"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6721,6 +6721,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "zcash_tachyon"
+version = "0.0.0"
+source = "git+http://github.com/tachyon-zcash/tachyon?rev=38ca55b#38ca55b95bb0aebd76bd6777c2850504a9e68c33"
+dependencies = [
+ "bitvec",
+ "blake2b_simd",
+ "ff",
+ "group",
+ "pasta_curves",
+ "proptest",
+ "rand 0.8.5",
+ "reddsa",
+]
+
+[[package]]
 name = "zcash_transparent"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6808,6 +6823,7 @@ dependencies = [
  "zcash_primitives",
  "zcash_protocol",
  "zcash_script",
+ "zcash_tachyon",
  "zcash_transparent",
  "zebra-test",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,17 +1,17 @@
 [workspace]
 members = [
-        "zebrad",
-        "zebra-chain",
-        "zebra-network",
-        "zebra-state",
-        "zebra-script",
-        "zebra-consensus",
-        "zebra-rpc",
-        "zebra-node-services",
-        "zebra-test",
-        "zebra-utils",
-        "tower-batch-control",
-        "tower-fallback",
+    "zebrad",
+    "zebra-chain",
+    "zebra-network",
+    "zebra-state",
+    "zebra-script",
+    "zebra-consensus",
+    "zebra-rpc",
+    "zebra-node-services",
+    "zebra-test",
+    "zebra-utils",
+    "tower-batch-control",
+    "tower-fallback",
 ]
 
 # Use the edition 2021 dependency resolver in the workspace, to match the crates
@@ -31,7 +31,6 @@ zcash_primitives = "0.26"
 zcash_proofs = "0.26"
 zcash_transparent = "0.6"
 zcash_protocol = "0.7"
-zip32 = "0.2"
 abscissa_core = "0.7"
 atty = "0.2.14"
 base64 = "0.22.1"
@@ -59,12 +58,10 @@ dirs = "6.0"
 ed25519-zebra = "4.0.3"
 elasticsearch = { version = "8.17.0-alpha.1", default-features = false }
 equihash = "0.2.2"
-ff = "0.13"
 futures = "0.3.31"
 futures-core = "0.3.31"
 futures-util = "0.3.31"
 group = "0.13"
-halo2 = "0.3"
 hex = "0.4.3"
 hex-literal = "0.4"
 howudoin = "0.1"
@@ -79,7 +76,6 @@ indicatif = "0.17"
 inferno = { version = "0.12", default-features = false }
 insta = "1.42"
 itertools = "0.14"
-jsonrpc = "0.18"
 jsonrpsee = "0.24.8"
 jsonrpsee-proc-macros = "0.24.9"
 jsonrpsee-types = "0.24.9"
@@ -128,7 +124,6 @@ syn = "2.0.100"
 tempfile = "3.20"
 thiserror = "2.0"
 thread-priority = "1.2"
-tinyvec = "1.9"
 tokio = "1.44"
 tokio-stream = "0.1.17"
 tokio-test = "0.4"
@@ -207,13 +202,6 @@ overflow-checks = false
 incremental = false
 codegen-units = 16
 
-[profile.dev.package.halo2_gadgets]
-opt-level = 3
-debug-assertions = false
-overflow-checks = false
-incremental = false
-codegen-units = 16
-
 [profile.dev.package.bls12_381]
 opt-level = 3
 debug-assertions = false
@@ -242,34 +230,12 @@ overflow-checks = false
 incremental = false
 codegen-units = 16
 
-[profile.dev.package.ring]
-opt-level = 3
-debug-assertions = false
-overflow-checks = false
-incremental = false
-codegen-units = 16
-
-[profile.dev.package.spin]
-opt-level = 3
-debug-assertions = false
-overflow-checks = false
-incremental = false
-codegen-units = 16
-
-[profile.dev.package.untrusted]
-opt-level = 3
-debug-assertions = false
-overflow-checks = false
-incremental = false
-codegen-units = 16
-
 [profile.dev.package.bitvec]
 opt-level = 3
 debug-assertions = false
 overflow-checks = false
 incremental = false
 codegen-units = 16
-
 
 [profile.release]
 panic = "abort"
@@ -295,6 +261,6 @@ debug = false
 [workspace.lints.rust]
 # The linter should ignore these expected config flags/values
 unexpected_cfgs = { level = "warn", check-cfg = [
-    'cfg(tokio_unstable)', # Used by tokio-console
-    'cfg(zcash_unstable, values("zfuture", "nu6.1", "nu7"))' # Used in Zebra and librustzcash
+    'cfg(tokio_unstable)',                                    # Used by tokio-console
+    'cfg(zcash_unstable, values("zfuture", "nu6.1", "nu7"))', # Used in Zebra and librustzcash
 ] }

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -133,6 +133,7 @@ rand = { workspace = true, optional = true }
 rand_chacha = { workspace = true, optional = true }
 
 zebra-test = { path = "../zebra-test/", version = "2.0.1", optional = true }
+zcash_tachyon = { git = "http://github.com/tachyon-zcash/tachyon", rev = "38ca55b", version = "0.0.0" }
 
 [dev-dependencies]
 # Benchmarks

--- a/zebra-chain/src/lib.rs
+++ b/zebra-chain/src/lib.rs
@@ -37,6 +37,7 @@ pub mod serialization;
 pub mod shutdown;
 pub mod sprout;
 pub mod subtree;
+pub mod tachyon;
 pub mod transaction;
 pub mod transparent;
 pub mod value_balance;

--- a/zebra-chain/src/tachyon.rs
+++ b/zebra-chain/src/tachyon.rs
@@ -1,0 +1,51 @@
+//! Tachyon-related functionality.
+//!
+//! Tachyon is a scaling solution for Zcash that introduces:
+//! - Tachygrams: Unified 32-byte blobs (nullifiers or note commitments)
+//! - Actions: Spend/output operations with cv, rk, and signature
+//! - Stamps: Proof + tachygrams + anchor
+//! - Aggregate proof transactions via Ragu PCD
+//! - Out-of-band payment distribution (no ciphertexts on-chain)
+//!
+//! ## Type Structure
+//!
+//! ```text
+//! ShieldedData
+//! ├── value_balance: Amount
+//! ├── actions: Vec<Action>
+//! │   └── Action
+//! │       ├── cv: ValueCommitment
+//! │       ├── rk: RandomizedVerificationKey
+//! │       └── sig: SpendAuthSignature
+//! ├── binding_sig: Option<BindingSignature>
+//! └── stamp: Option<Stamp>
+//!     └── Stamp
+//!         ├── tachygrams: Vec<Tachygram>
+//!         ├── proof: Proof
+//!         └── anchor: Anchor
+//! ```
+//!
+//! ## Crate Organization
+//!
+//! Protocol types are re-exported from the `tachyon` crate. The only
+//! zebra-specific type is [`ShieldedData`] (bundle with runtime stamp
+//! optionality and serde).
+
+#![warn(missing_docs)]
+
+#[cfg(any(test, feature = "proptest-impl"))]
+mod arbitrary;
+
+pub mod shielded_data;
+
+// Re-export protocol types from tachyon crate
+pub use zcash_tachyon::value::Commitment as ValueCommitment;
+pub use zcash_tachyon::{
+    action::Signature as ActionSignature,
+    bundle::Signature as BindingSignature,
+    keys::public::{ActionVerificationKey, BindingVerificationKey},
+    Action, Anchor, Epoch, Proof, Stamp, Tachygram,
+};
+
+// Zebra-specific types
+pub use shielded_data::ShieldedData;

--- a/zebra-chain/src/tachyon/arbitrary.rs
+++ b/zebra-chain/src/tachyon/arbitrary.rs
@@ -1,0 +1,79 @@
+//! Proptest arbitrary implementations for Tachyon types.
+//!
+//! These implement `Arbitrary` for tachyon crate types (orphan rule is
+//! satisfied because proptest is a dev-dependency) and for zebra's
+//! `ShieldedData`.
+
+use proptest::{arbitrary::any, prelude::*};
+
+use halo2::pasta::pallas;
+
+use crate::amount::Amount;
+
+use super::ShieldedData;
+
+impl Arbitrary for ShieldedData {
+    type Parameters = ();
+    type Strategy = BoxedStrategy<Self>;
+
+    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+        (
+            proptest::collection::vec(arb_action(), 0..5),
+            any::<i64>(),
+            proptest::option::of(arb_stamp()),
+        )
+            .prop_map(|(actions, vb, stamp)| {
+                let value_balance = Amount::try_from(vb % 1000).unwrap_or_else(|_| Amount::zero());
+                let binding_sig = if !actions.is_empty() {
+                    Some(tachyon::BindingSignature::from([0u8; 64]))
+                } else {
+                    None
+                };
+                ShieldedData {
+                    actions,
+                    value_balance,
+                    binding_sig,
+                    stamp,
+                }
+            })
+            .boxed()
+    }
+}
+
+fn arb_action() -> impl Strategy<Value = tachyon::Action> {
+    (any::<bool>(), any::<[u8; 32]>(), any::<[u8; 64]>()).prop_map(
+        |(use_identity, rk_bytes, sig_bytes)| {
+            let cv = if use_identity {
+                super::ValueCommitment::balance(0)
+            } else {
+                super::ValueCommitment::balance(1)
+            };
+            // Fallback to a known-good key if random bytes are invalid
+            let rk = tachyon::RandomizedVerificationKey::try_from(rk_bytes).unwrap_or_else(|_| {
+                tachyon::RandomizedVerificationKey::try_from([1u8; 32]).unwrap()
+            });
+            let sig = tachyon::SpendAuthSignature::from(sig_bytes);
+            tachyon::Action { cv, rk, sig }
+        },
+    )
+}
+
+fn arb_stamp() -> impl Strategy<Value = tachyon::Stamp> {
+    (
+        proptest::collection::vec(arb_tachygram(), 0..20),
+        arb_anchor(),
+    )
+        .prop_map(|(tachygrams, anchor)| tachyon::Stamp {
+            tachygrams,
+            anchor,
+            proof: tachyon::Proof::default(),
+        })
+}
+
+fn arb_tachygram() -> impl Strategy<Value = tachyon::Tachygram> {
+    any::<u64>().prop_map(|val| tachyon::Tachygram::from(pallas::Base::from(val)))
+}
+
+fn arb_anchor() -> impl Strategy<Value = tachyon::Anchor> {
+    any::<u64>().prop_map(|val| tachyon::Anchor::from(pallas::Base::from(val)))
+}

--- a/zebra-chain/src/tachyon/shielded_data.rs
+++ b/zebra-chain/src/tachyon/shielded_data.rs
@@ -1,0 +1,230 @@
+//! Tachyon shielded data for transactions.
+//!
+//! [`ShieldedData`] is the zebra-chain representation of a Tachyon bundle,
+//! using tachyon crate types directly for its fields. Serde is implemented
+//! at the bundle level via a proxy struct pattern.
+//!
+//! ## Stamp optionality
+//!
+//! A bundle's stamp is `Option<Stamp>`:
+//! - `Some`: bundle carries its own proof and tachygrams
+//! - `None`: stamp was stripped and merged into another bundle in the same block
+
+use std::fmt;
+
+use halo2::pasta::{group::ff::PrimeField, pallas};
+
+use crate::amount::{Amount, NegativeAllowed};
+
+/// Tachyon shielded data bundle for a transaction.
+///
+/// Uses tachyon crate types directly. Serde is implemented at the bundle
+/// level — individual tachyon types do not carry serde derives.
+#[derive(Clone)]
+pub struct ShieldedData {
+    /// The actions (cv, rk, sig for each).
+    pub actions: Vec<zcash_tachyon::Action>,
+
+    /// Net value of Tachyon spends minus outputs.
+    pub value_balance: Amount<NegativeAllowed>,
+
+    /// Binding signature on transaction sighash.
+    /// None when actions is empty (nothing to sign over).
+    pub binding_sig: Option<zcash_tachyon::bundle::Signature>,
+
+    /// The stamp containing tachygrams, anchor, and proof.
+    /// None after stripping during aggregation.
+    pub stamp: Option<zcash_tachyon::Stamp>,
+}
+
+impl fmt::Debug for ShieldedData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut debug = f.debug_struct("Tachyon ShieldedData");
+        debug
+            .field("actions", &self.actions.len())
+            .field("value_balance", &self.value_balance);
+
+        if let Some(ref stamp) = self.stamp {
+            debug.field("stamp", &format!("{} tachygrams", stamp.tachygrams.len()));
+        } else {
+            debug.field("stamp", &"None (stripped)");
+        }
+
+        debug.finish()
+    }
+}
+
+impl fmt::Display for ShieldedData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(self, f)
+    }
+}
+
+impl ShieldedData {
+    /// Iterate over the actions in this bundle.
+    pub fn actions(&self) -> impl Iterator<Item = &zcash_tachyon::Action> {
+        self.actions.iter()
+    }
+
+    /// Get the value balance of this bundle.
+    pub fn value_balance(&self) -> Amount<NegativeAllowed> {
+        self.value_balance
+    }
+
+    /// Count the number of actions in this bundle.
+    pub fn actions_count(&self) -> usize {
+        self.actions.len()
+    }
+
+    /// Calculate the binding verification key.
+    ///
+    /// `bvk = sum(cv_i) - [value_balance] V`
+    ///
+    /// Follows Orchard's `binding_validating_key()` pattern. The binding
+    /// signature proves that the signer knew all value commitment trapdoors,
+    /// which transitively proves value balance integrity.
+    /// Returns None if there are no actions.
+    pub fn binding_verification_key(
+        &self,
+    ) -> Option<zcash_tachyon::keys::public::BindingVerificationKey> {
+        if self.actions.is_empty() {
+            return None;
+        }
+
+        Some(zcash_tachyon::keys::public::BindingVerificationKey::derive(
+            &self.actions,
+            self.value_balance.into(),
+        ))
+    }
+}
+
+// =============================================================================
+// Serde — implemented at the bundle level via proxy structs
+// =============================================================================
+
+use serde_big_array::BigArray;
+
+/// Serde proxy for a single Action.
+#[derive(Serialize, Deserialize)]
+struct ActionProxy {
+    cv: [u8; 32],
+    rk: [u8; 32],
+    #[serde(with = "BigArray")]
+    sig: [u8; 64],
+}
+
+impl From<zcash_tachyon::Action> for ActionProxy {
+    fn from(a: zcash_tachyon::Action) -> Self {
+        ActionProxy {
+            cv: a.cv.into(),
+            rk: a.rk.into(),
+            sig: a.sig.into(),
+        }
+    }
+}
+
+/// Serde proxy for a Stamp.
+#[derive(Serialize, Deserialize)]
+struct StampProxy {
+    tachygrams: Vec<[u8; 32]>,
+    anchor: [u8; 32],
+    #[serde(with = "BigArray")]
+    proof: [u8; 192],
+}
+
+/// Serde proxy for ShieldedData.
+#[derive(Serialize, Deserialize)]
+struct ShieldedDataProxy {
+    actions: Vec<ActionProxy>,
+    value_balance: Amount<NegativeAllowed>,
+    binding_sig: Option<BindingSigBytes>,
+    stamp: Option<StampProxy>,
+}
+
+/// Wrapper for binding signature bytes with serde support.
+#[derive(Serialize, Deserialize)]
+struct BindingSigBytes(#[serde(with = "BigArray")] [u8; 64]);
+
+impl serde::Serialize for ShieldedData {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let proxy = ShieldedDataProxy {
+            actions: self.actions.iter().map(|a| ActionProxy::from(*a)).collect(),
+            value_balance: self.value_balance,
+            binding_sig: self
+                .binding_sig
+                .as_ref()
+                .map(|s| BindingSigBytes(<[u8; 64]>::from(*s))),
+            stamp: self.stamp.as_ref().map(|s| StampProxy {
+                tachygrams: s
+                    .tachygrams
+                    .iter()
+                    .map(|tg| pallas::Base::from(*tg).to_repr())
+                    .collect(),
+                anchor: pallas::Base::from(s.anchor).to_repr(),
+                proof: {
+                    let bytes: [u8; 192] = s.proof.into();
+                    bytes
+                },
+            }),
+        };
+        proxy.serialize(serializer)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for ShieldedData {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let proxy = ShieldedDataProxy::deserialize(deserializer)?;
+
+        let actions = proxy
+            .actions
+            .into_iter()
+            .map(|a| {
+                let cv = zcash_tachyon::value::Commitment::try_from(&a.cv)
+                    .map_err(serde::de::Error::custom)?;
+                let rk = zcash_tachyon::keys::public::ActionVerificationKey::try_from(a.rk)
+                    .map_err(serde::de::Error::custom)?;
+                let sig = zcash_tachyon::action::Signature::from(a.sig);
+                Ok(zcash_tachyon::Action { cv, rk, sig })
+            })
+            .collect::<Result<Vec<_>, D::Error>>()?;
+
+        let binding_sig = proxy
+            .binding_sig
+            .map(|b| zcash_tachyon::bundle::Signature::from(b.0));
+
+        let stamp = proxy
+            .stamp
+            .map(|s| {
+                let tachygrams = s
+                    .tachygrams
+                    .into_iter()
+                    .map(|bytes| {
+                        <Option<pallas::Base>>::from(pallas::Base::from_repr(bytes))
+                            .map(|fp| zcash_tachyon::Tachygram::from(fp))
+                            .ok_or_else(|| serde::de::Error::custom("invalid field element"))
+                    })
+                    .collect::<Result<Vec<_>, D::Error>>()?;
+
+                let anchor = <Option<pallas::Base>>::from(pallas::Base::from_repr(s.anchor))
+                    .map(|fp| zcash_tachyon::Anchor::from(fp))
+                    .ok_or_else(|| serde::de::Error::custom("invalid field element"))?;
+
+                let proof =
+                    zcash_tachyon::Proof::try_from(&s.proof).map_err(serde::de::Error::custom)?;
+
+                Ok(zcash_tachyon::Stamp {
+                    tachygrams,
+                    anchor,
+                    proof,
+                })
+            })
+            .transpose()?;
+
+        Ok(ShieldedData {
+            actions,
+            value_balance: proxy.value_balance,
+            binding_sig,
+            stamp,
+        })
+    }
+}

--- a/zebra-chain/src/transaction/serialize.rs
+++ b/zebra-chain/src/transaction/serialize.rs
@@ -4,7 +4,7 @@
 use std::{borrow::Borrow, io, sync::Arc};
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
-use halo2::pasta::group::ff::PrimeField;
+use halo2::pasta::{group::ff::PrimeField, pallas};
 use hex::FromHex;
 use reddsa::{orchard::Binding, orchard::SpendAuth, Signature};
 
@@ -14,10 +14,12 @@ use crate::{
     parameters::{OVERWINTER_VERSION_GROUP_ID, SAPLING_VERSION_GROUP_ID, TX_V5_VERSION_GROUP_ID},
     primitives::{Halo2Proof, ZkSnarkProof},
     serialization::{
-        zcash_deserialize_external_count, zcash_serialize_empty_list,
-        zcash_serialize_external_count, AtLeastOne, ReadZcashExt, SerializationError,
-        TrustedPreallocate, ZcashDeserialize, ZcashDeserializeInto, ZcashSerialize,
+        zcash_deserialize_external_count, zcash_serialize_bytes, zcash_serialize_empty_list,
+        zcash_serialize_external_count, AtLeastOne, CompactSizeMessage, ReadZcashExt,
+        SerializationError, TrustedPreallocate, ZcashDeserialize, ZcashDeserializeInto,
+        ZcashSerialize,
     },
+    tachyon,
 };
 
 #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
@@ -463,6 +465,167 @@ impl<T: reddsa::SigType> ZcashSerialize for reddsa::Signature<T> {
 impl<T: reddsa::SigType> ZcashDeserialize for reddsa::Signature<T> {
     fn zcash_deserialize<R: io::Read>(mut reader: R) -> Result<Self, SerializationError> {
         Ok(reader.read_64_bytes()?.into())
+    }
+}
+
+// Tachyon ShieldedData serialization
+//
+// Wire format (counts first, conditional fields):
+//
+// nTachygrams    : compactsize (0 if stripped)
+// nActions       : compactsize
+// vActions       : nActions × 128 bytes     (if nActions > 0)
+// valueBalance   : i64                      (if nActions > 0)
+// bindingSig     : 64 bytes                 (if nActions > 0)
+// anchor         : 32 bytes                 (if nTachygrams > 0)
+// vTachygrams    : nTachygrams × 32 bytes   (if nTachygrams > 0)
+// proof          : size-prefixed bytes      (if nTachygrams > 0)
+//
+// Bundle categories based on counts:
+// - None:      nTachygrams = 0, nActions = 0
+// - Adjunct:   nTachygrams = 0, nActions > 0 (stripped)
+// - Autonome:  nTachygrams = nActions > 0 (self-contained)
+// - Aggregate: nTachygrams > nActions (carries others' tachygrams)
+//   - Based:    nActions > 0 ("based" = coinbase, miner shielding rewards)
+//   - Innocent: nActions = 0 (only carries tachystamps)
+
+impl ZcashSerialize for Option<tachyon::ShieldedData> {
+    fn zcash_serialize<W: io::Write>(&self, mut writer: W) -> Result<(), io::Error> {
+        match self {
+            None => {
+                // Empty tachyon data: nTachygrams = 0, nActions = 0
+                zcash_serialize_empty_list(&mut writer)?;
+                zcash_serialize_empty_list(writer)?;
+            }
+            Some(tachyon_shielded_data) => {
+                tachyon_shielded_data.zcash_serialize(&mut writer)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl ZcashSerialize for tachyon::ShieldedData {
+    fn zcash_serialize<W: io::Write>(&self, mut writer: W) -> Result<(), io::Error> {
+        // Counts first
+        let n_tachygrams = self.stamp.as_ref().map(|s| s.tachygrams.len()).unwrap_or(0); // 0 if stripped
+        CompactSizeMessage::try_from(n_tachygrams)?.zcash_serialize(&mut writer)?;
+        CompactSizeMessage::try_from(self.actions.len())?.zcash_serialize(&mut writer)?;
+
+        // Action fields (conditional on nActions > 0)
+        if !self.actions.is_empty() {
+            for action in self.actions.iter() {
+                let cv_bytes: [u8; 32] = action.cv.into();
+                let rk_bytes: [u8; 32] = action.rk.into();
+                let sig_bytes: [u8; 64] = action.sig.into();
+                writer.write_all(&cv_bytes)?; // cv: 32 bytes
+                writer.write_all(&rk_bytes)?; // rk: 32 bytes
+                writer.write_all(&sig_bytes)?; // sig: 64 bytes
+            }
+            self.value_balance.zcash_serialize(&mut writer)?;
+            // binding_sig must be Some when actions is non-empty
+            let binding_sig = self
+                .binding_sig
+                .expect("binding_sig required when actions present");
+            writer.write_all(&<[u8; 64]>::from(binding_sig))?;
+        }
+
+        // Stamp fields at end (stripped in adjuncts)
+        if let Some(stamp) = &self.stamp {
+            writer.write_all(&pallas::Base::from(stamp.anchor).to_repr())?; // anchor: 32 bytes
+            for tg in &stamp.tachygrams {
+                writer.write_all(&pallas::Base::from(*tg).to_repr())?; // tachygram: 32 bytes each
+            }
+            // proof: size-prefixed (placeholder — empty for now)
+            zcash_serialize_bytes(&Vec::new(), &mut writer)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl ZcashDeserialize for Option<tachyon::ShieldedData> {
+    fn zcash_deserialize<R: io::Read>(mut reader: R) -> Result<Self, SerializationError> {
+        // Counts first
+        let n_tachygrams: usize = (&mut reader)
+            .zcash_deserialize_into::<CompactSizeMessage>()?
+            .into();
+        let n_actions: usize = (&mut reader)
+            .zcash_deserialize_into::<CompactSizeMessage>()?
+            .into();
+
+        if n_tachygrams == 0 && n_actions == 0 {
+            return Ok(None);
+        }
+
+        // Action fields (conditional on nActions > 0)
+        let (actions, value_balance, binding_sig) = if n_actions > 0 {
+            let mut actions = Vec::with_capacity(n_actions);
+            for _ in 0..n_actions {
+                let cv_bytes: [u8; 32] = reader.read_32_bytes()?;
+
+                let cv = tachyon::ValueCommitment::try_from(&cv_bytes)
+                    .map_err(|_| SerializationError::Parse("Invalid ValueCommitment in action"))?;
+
+                let rk_bytes: [u8; 32] = reader.read_32_bytes()?;
+                let rk = tachyon::ActionVerificationKey::try_from(rk_bytes)
+                    .map_err(|_| SerializationError::Parse("Invalid verification key in action"))?;
+
+                let sig_bytes: [u8; 64] = reader.read_64_bytes()?;
+                let sig = tachyon::ActionSignature::from(sig_bytes);
+
+                actions.push(tachyon::Action { cv, rk, sig });
+            }
+
+            let value_balance: amount::Amount = (&mut reader).zcash_deserialize_into()?;
+            let binding_sig_bytes: [u8; 64] = reader.read_64_bytes()?;
+            let binding_sig = tachyon::BindingSignature::from(binding_sig_bytes);
+
+            (actions, value_balance, Some(binding_sig))
+        } else {
+            // Pure aggregate: no actions, no value flow, no binding sig
+            (Vec::new(), amount::Amount::zero(), None)
+        };
+
+        // Stamp fields at end (if present)
+        let stamp = if n_tachygrams > 0 {
+            // anchor: 32 bytes
+            let anchor_bytes: [u8; 32] = reader.read_32_bytes()?;
+            let anchor = <Option<pallas::Base>>::from(pallas::Base::from_repr(anchor_bytes))
+                .map(tachyon::Anchor::from)
+                .ok_or(SerializationError::Parse("Invalid field element in anchor"))?;
+
+            // vTachygrams: n × 32 bytes
+            let mut tachygrams = Vec::with_capacity(n_tachygrams);
+            for _ in 0..n_tachygrams {
+                let bytes: [u8; 32] = reader.read_32_bytes()?;
+                let tg = <Option<pallas::Base>>::from(pallas::Base::from_repr(bytes))
+                    .map(tachyon::Tachygram::from)
+                    .ok_or(SerializationError::Parse(
+                        "Invalid field element in tachygram",
+                    ))?;
+                tachygrams.push(tg);
+            }
+
+            // proof: size-prefixed (placeholder — read and discard)
+            let _proof_bytes: Vec<u8> = (&mut reader).zcash_deserialize_into()?;
+            let proof = tachyon::Proof::default();
+
+            Some(tachyon::Stamp {
+                tachygrams,
+                proof,
+                anchor,
+            })
+        } else {
+            None
+        };
+
+        Ok(Some(tachyon::ShieldedData {
+            actions,
+            value_balance,
+            binding_sig,
+            stamp,
+        }))
     }
 }
 


### PR DESCRIPTION
Tachyon foundation: extract crate and integrate via git dependency

Replaces #19.

The [`zcash_tachyon` crate](https://github.com/tachyon-zcash/tachyon) defines
the Tachyon shielded protocol types. `zebra-chain` depends on it via git and
provides `ShieldedData` with serde, wire serialization, and proptest.

Tachyon's `todo!` stubs:

- `Note::commitment`
- `Note::nullifier`
- `Proof::create`
- `Proof::merge`
- `Proof::verify`

## Protocol

**Note** (104 bytes) — `{ pk: PaymentKey, value: Value, psi: NullifierTrapdoor, rcm: CommitmentTrapdoor }`. All fields 32 bytes except `value` (8 bytes).

**Action** (128 bytes) — `{ cv: value::Commitment, rk: RandomizedVerificationKey, sig: SpendAuthSignature }`. `spend()` and `output()` produce an action-witness tuple. Sigs cover `H("Tachyon-SpendSig", cv || rk)` at construction time (no sighash circular dependency).

**Keys** — RedPallas, like Orchard. Type system constraints key purpose and state. `SpendAuthorizingKey` derives `SpendValidatingKey` derives `RandomizedVerificationKey`. Value commitments derive `BindingVerificationKey`.

**Primitives** — `Tachygram(Fp)`, `Anchor(Fp)`, `Epoch(Fp)`. Anchor and epoch are presently the same.

**Stamp** — `{ tachygrams: Vec<Tachygram>, anchor: Anchor, proof: Proof }`. Proof is a unit struct with `Into<[u8; 192]>` / `TryFrom<&[u8; 192]>` stubs (actual encoding TBD by Ragu). `prove()` and `merge()` are stubbed.

**Bundle<S, V>** (176 bytes fixed + heap) — `{ actions: Vec<Action>, value_balance: V, binding_sig: BindingSignature, stamp: S }`. `Stamped<V>` (has stamp) / `Stripped<V>` (stamp removed). `build()` collects actions, signs binding sig (BLAKE2b-512 over `value_balance` + action sigs), creates proof (stub). `strip()` separates stamp for aggregation. Stamp excluded from binding sighash. `BindingVerificationKey::derive(&actions, value_balance)` computes `bvk = sum(cv_i) - [value_balance]V`.

## Wire format

| Field | Size | Condition |
| ----- | ---- | --------- |
| `nTachygrams` | compactsize | always |
| `nActions` | compactsize | always |
| `vActions` | n x 128 B | nActions > 0 |
| `valueBalance` | 8 B | nActions > 0 |
| `bindingSig` | 64 B | nActions > 0 |
| `anchor` | 32 B | nTachygrams > 0 |
| `vTachygrams` | n x 32 B | nTachygrams > 0 |
| `proof` | size-prefixed | nTachygrams > 0 |

## zebra-chain integration

```
ShieldedData { actions, value_balance, binding_sig?, stamp? }
  Action { cv, rk, sig }
  Stamp  { tachygrams, proof, anchor }
```

Protocol types re-exported from `zcash_tachyon` crate via `crate::tachyon`.
`ShieldedData` is the only zebra-specific type (runtime stamp optionality +
serde proxy structs). Most types have direct byte conversions (`Into<[u8; N]>`,
`TryFrom<[u8; N]>`). Tachygrams and anchors convert through shared
`pallas::Base` (`Fp`) since both crates use `pasta_curves` from crates.io.
