### PR TITLE
stubbing: aggregation enforcement and verification

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,7 +6,7 @@ rustflags = [
     # Zebra standard lints for Rust 1.65+
 
     # High-risk code
-    "-Dunsafe_code",
+    # "-Dunsafe_code",
     "-Dnon_ascii_idents",
 
     # Potential bugs
@@ -90,4 +90,4 @@ rustdocflags = [
 ]
 
 [env]
-RUST_BACKTRACE="1"
+RUST_BACKTRACE = "1"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6721,6 +6721,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "zcash_tachyon"
+version = "0.0.0"
+source = "git+http://github.com/tachyon-zcash/tachyon?rev=1ff9b78#1ff9b7823c2c996bec4bd47a12d9c3fce4a9ae57"
+dependencies = [
+ "bitvec",
+ "blake2b_simd",
+ "ff",
+ "group",
+ "pasta_curves",
+ "proptest",
+ "rand 0.8.5",
+ "reddsa",
+]
+
+[[package]]
 name = "zcash_transparent"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6808,6 +6823,7 @@ dependencies = [
  "zcash_primitives",
  "zcash_protocol",
  "zcash_script",
+ "zcash_tachyon",
  "zcash_transparent",
  "zebra-test",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6723,7 +6723,6 @@ dependencies = [
 [[package]]
 name = "zcash_tachyon"
 version = "0.0.0"
-source = "git+http://github.com/tachyon-zcash/tachyon?rev=1ff9b78#1ff9b7823c2c996bec4bd47a12d9c3fce4a9ae57"
 dependencies = [
  "bitvec",
  "blake2b_simd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1550,6 +1550,14 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.2.2"
+dependencies = [
+ "blake2b_simd",
+ "core2",
+]
+
+[[package]]
+name = "equihash"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca4f333d4ccc9d23c06593733673026efa71a332e028b00f12cf427b9677dce9"
 dependencies = [
@@ -1598,8 +1606,6 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d42773cb15447644d170be20231a3268600e0c4cea8987d013b93ac973d3cf7"
 dependencies = [
  "blake2b_simd",
 ]
@@ -1944,6 +1950,26 @@ name = "halo2_gadgets"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73a5e510d58a07d8ed238a5a8a436fe6c2c79e1bb2611f62688bc65007b4e6e7"
+dependencies = [
+ "arrayvec",
+ "bitvec",
+ "ff",
+ "group",
+ "halo2_poseidon",
+ "halo2_proofs",
+ "lazy_static",
+ "pasta_curves",
+ "rand 0.8.5",
+ "sinsemilla",
+ "subtle",
+ "uint 0.9.5",
+]
+
+[[package]]
+name = "halo2_gadgets"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45824ce0dd12e91ec0c68ebae2a7ed8ae19b70946624c849add59f1d1a62a143"
 dependencies = [
  "arrayvec",
  "bitvec",
@@ -3195,7 +3221,7 @@ dependencies = [
  "fpe",
  "getset",
  "group",
- "halo2_gadgets",
+ "halo2_gadgets 0.3.1",
  "halo2_poseidon",
  "halo2_proofs",
  "hex",
@@ -3205,6 +3231,42 @@ dependencies = [
  "nonempty",
  "pasta_curves",
  "rand 0.8.5",
+ "reddsa",
+ "serde",
+ "sinsemilla",
+ "subtle",
+ "tracing",
+ "visibility",
+ "zcash_note_encryption",
+ "zcash_spec",
+ "zip32",
+]
+
+[[package]]
+name = "orchard"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01cd4ea711aab5f263f2b7aa6966687a2d6c7df4f78eb1b97a66a7a4e78e3b"
+dependencies = [
+ "aes",
+ "bitvec",
+ "blake2b_simd",
+ "core2",
+ "ff",
+ "fpe",
+ "getset",
+ "group",
+ "halo2_gadgets 0.4.0",
+ "halo2_poseidon",
+ "halo2_proofs",
+ "hex",
+ "incrementalmerkletree",
+ "lazy_static",
+ "memuse",
+ "nonempty",
+ "pasta_curves",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "reddsa",
  "serde",
  "sinsemilla",
@@ -4411,6 +4473,39 @@ name = "sapling-crypto"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9d3c081c83f1dc87403d9d71a06f52301c0aa9ea4c17da2a3435bbf493ffba4"
+dependencies = [
+ "aes",
+ "bellman",
+ "bitvec",
+ "blake2b_simd",
+ "blake2s_simd",
+ "bls12_381",
+ "core2",
+ "document-features",
+ "ff",
+ "fpe",
+ "getset",
+ "group",
+ "hex",
+ "incrementalmerkletree",
+ "jubjub",
+ "lazy_static",
+ "memuse",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "redjubjub",
+ "subtle",
+ "tracing",
+ "zcash_note_encryption",
+ "zcash_spec",
+ "zip32",
+]
+
+[[package]]
+name = "sapling-crypto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5433ab8c1cd52dfad3b903143e371d5bdd514ab7952f71414e6d66a5da8223cd"
 dependencies = [
  "aes",
  "bellman",
@@ -6504,9 +6599,9 @@ dependencies = [
 
 [[package]]
 name = "xdg"
-version = "2.5.2"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
+checksum = "2fb433233f2df9344722454bc7e96465c9d03bff9d77c248f9e7523fe79585b5"
 
 [[package]]
 name = "yaml-rust2"
@@ -6545,9 +6640,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_address"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16da37aff6d1a72a917e649cd337ab750c87efc6eeb36d75a47a9a2f71df195f"
+version = "0.10.1"
 dependencies = [
  "bech32",
  "bs58",
@@ -6560,18 +6653,15 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bca38087e6524e5f51a5b0fb3fc18f36d7b84bf67b2056f494ca0c281590953d"
 dependencies = [
  "core2",
+ "hex",
  "nonempty",
 ]
 
 [[package]]
 name = "zcash_history"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fde17bf53792f9c756b313730da14880257d7661b5bfc69d0571c3a7c11a76d"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -6581,8 +6671,6 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c115531caa1b7ca5ccd82dc26dbe3ba44b7542e928a3f77cd04abbe3cde4a4f2"
 dependencies = [
  "bech32",
  "blake2b_simd",
@@ -6593,7 +6681,9 @@ dependencies = [
  "group",
  "memuse",
  "nonempty",
+ "orchard 0.12.0",
  "rand_core 0.6.4",
+ "sapling-crypto 0.6.0",
  "secrecy",
  "subtle",
  "tracing",
@@ -6619,9 +6709,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_primitives"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d9e2a8ea37c3b839dc9079747a25789f50cd6a374086e23fc90951e2bcfa37"
+version = "0.26.4"
 dependencies = [
  "bip32",
  "blake2b_simd",
@@ -6630,7 +6718,7 @@ dependencies = [
  "core2",
  "crypto-common 0.2.0-rc.1",
  "document-features",
- "equihash",
+ "equihash 0.2.2",
  "ff",
  "fpe",
  "getset",
@@ -6640,12 +6728,13 @@ dependencies = [
  "jubjub",
  "memuse",
  "nonempty",
- "orchard",
+ "orchard 0.12.0",
+ "pasta_curves",
  "rand 0.8.5",
  "rand_core 0.6.4",
  "redjubjub",
  "ripemd 0.1.3",
- "sapling-crypto",
+ "sapling-crypto 0.6.0",
  "secp256k1",
  "sha2 0.10.9",
  "subtle",
@@ -6656,15 +6745,14 @@ dependencies = [
  "zcash_protocol",
  "zcash_script",
  "zcash_spec",
+ "zcash_tachyon",
  "zcash_transparent",
  "zip32",
 ]
 
 [[package]]
 name = "zcash_proofs"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf3e1bc0e9006a7fd2e6bb4603b1ad512f87c2e092851a9e1f5282df7dbc87d0"
+version = "0.26.1"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -6674,10 +6762,9 @@ dependencies = [
  "home",
  "jubjub",
  "known-folders",
- "lazy_static",
  "rand_core 0.6.4",
  "redjubjub",
- "sapling-crypto",
+ "sapling-crypto 0.6.0",
  "tracing",
  "wagyu-zcash-parameters",
  "xdg",
@@ -6686,14 +6773,13 @@ dependencies = [
 
 [[package]]
 name = "zcash_protocol"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01fb174be84135a00fd3799161835e46f320d0028dd9446fdbd97a8d928456b6"
+version = "0.7.2"
 dependencies = [
  "core2",
  "document-features",
  "hex",
  "memuse",
+ "zcash_encoding",
 ]
 
 [[package]]
@@ -6702,8 +6788,10 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bed6cf5b2b4361105d4ea06b2752f0c8af4641756c7fbc9858a80af186c234f"
 dependencies = [
+ "bip32",
  "bitflags 2.9.4",
  "bounded-vec",
+ "hex",
  "ripemd 0.1.3",
  "secp256k1",
  "sha1",
@@ -6736,9 +6824,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_transparent"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "539b66f06f6bbdc135b9dc0dba879b0b354b4078d498cd1c4dae28038ec90a33"
+version = "0.6.3"
 dependencies = [
  "bip32",
  "blake2b_simd",
@@ -6747,6 +6833,7 @@ dependencies = [
  "document-features",
  "getset",
  "hex",
+ "nonempty",
  "ripemd 0.1.3",
  "secp256k1",
  "sha2 0.10.9",
@@ -6777,7 +6864,7 @@ dependencies = [
  "derive-getters",
  "dirs",
  "ed25519-zebra",
- "equihash",
+ "equihash 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures",
  "group",
  "halo2_proofs",
@@ -6788,7 +6875,7 @@ dependencies = [
  "jubjub",
  "lazy_static",
  "num-integer",
- "orchard",
+ "orchard 0.11.0",
  "primitive-types",
  "proptest",
  "proptest-derive",
@@ -6799,7 +6886,7 @@ dependencies = [
  "reddsa",
  "redjubjub",
  "ripemd 0.1.3",
- "sapling-crypto",
+ "sapling-crypto 0.5.0",
  "secp256k1",
  "serde",
  "serde-big-array",
@@ -6848,12 +6935,12 @@ dependencies = [
  "mset",
  "num-integer",
  "once_cell",
- "orchard",
+ "orchard 0.11.0",
  "proptest",
  "proptest-derive",
  "rand 0.8.5",
  "rayon",
- "sapling-crypto",
+ "sapling-crypto 0.5.0",
  "serde",
  "spandoc",
  "thiserror 2.0.17",
@@ -6951,7 +7038,7 @@ dependencies = [
  "proptest",
  "prost 0.14.1",
  "rand 0.8.5",
- "sapling-crypto",
+ "sapling-crypto 0.5.0",
  "semver",
  "serde",
  "serde_json",
@@ -7029,7 +7116,7 @@ dependencies = [
  "regex",
  "rlimit",
  "rocksdb",
- "sapling-crypto",
+ "sapling-crypto 0.5.0",
  "semver",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,14 +23,14 @@ resolver = "2"
 incrementalmerkletree = { version = "0.8.2", features = ["legacy-api"] }
 orchard = "0.11"
 sapling-crypto = "0.5"
-zcash_address = "0.10"
-zcash_encoding = "0.3"
-zcash_history = "0.4"
-zcash_keys = "0.12"
-zcash_primitives = "0.26"
-zcash_proofs = "0.26"
-zcash_transparent = "0.6"
-zcash_protocol = "0.7"
+zcash_address = {path="../librustzcash/components/zcash_address"}
+zcash_encoding = {path="../librustzcash/components/zcash_encoding"}
+zcash_history = {path="../librustzcash/zcash_history"}
+zcash_keys = {path = "../librustzcash/zcash_keys"}
+zcash_primitives = {path = "../librustzcash/zcash_primitives"}
+zcash_proofs = {path = "../librustzcash/zcash_proofs"}
+zcash_transparent = {path = "../librustzcash/zcash_transparent"}
+zcash_protocol = {path="../librustzcash/components/zcash_protocol"}
 abscissa_core = "0.7"
 atty = "0.2.14"
 base64 = "0.22.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,17 +1,17 @@
 [workspace]
 members = [
-        "zebrad",
-        "zebra-chain",
-        "zebra-network",
-        "zebra-state",
-        "zebra-script",
-        "zebra-consensus",
-        "zebra-rpc",
-        "zebra-node-services",
-        "zebra-test",
-        "zebra-utils",
-        "tower-batch-control",
-        "tower-fallback",
+    "zebrad",
+    "zebra-chain",
+    "zebra-network",
+    "zebra-state",
+    "zebra-script",
+    "zebra-consensus",
+    "zebra-rpc",
+    "zebra-node-services",
+    "zebra-test",
+    "zebra-utils",
+    "tower-batch-control",
+    "tower-fallback",
 ]
 
 # Use the edition 2021 dependency resolver in the workspace, to match the crates
@@ -31,7 +31,6 @@ zcash_primitives = "0.26"
 zcash_proofs = "0.26"
 zcash_transparent = "0.6"
 zcash_protocol = "0.7"
-zip32 = "0.2"
 abscissa_core = "0.7"
 atty = "0.2.14"
 base64 = "0.22.1"
@@ -59,12 +58,10 @@ dirs = "6.0"
 ed25519-zebra = "4.0.3"
 elasticsearch = { version = "8.17.0-alpha.1", default-features = false }
 equihash = "0.2.2"
-ff = "0.13"
 futures = "0.3.31"
 futures-core = "0.3.31"
 futures-util = "0.3.31"
 group = "0.13"
-halo2 = "0.3"
 hex = "0.4.3"
 hex-literal = "0.4"
 howudoin = "0.1"
@@ -79,7 +76,6 @@ indicatif = "0.17"
 inferno = { version = "0.12", default-features = false }
 insta = "1.42"
 itertools = "0.14"
-jsonrpc = "0.18"
 jsonrpsee = "0.24.8"
 jsonrpsee-proc-macros = "0.24.9"
 jsonrpsee-types = "0.24.9"
@@ -128,7 +124,6 @@ syn = "2.0.100"
 tempfile = "3.20"
 thiserror = "2.0"
 thread-priority = "1.2"
-tinyvec = "1.9"
 tokio = "1.44"
 tokio-stream = "0.1.17"
 tokio-test = "0.4"
@@ -207,13 +202,6 @@ overflow-checks = false
 incremental = false
 codegen-units = 16
 
-[profile.dev.package.halo2_gadgets]
-opt-level = 3
-debug-assertions = false
-overflow-checks = false
-incremental = false
-codegen-units = 16
-
 [profile.dev.package.bls12_381]
 opt-level = 3
 debug-assertions = false
@@ -242,34 +230,12 @@ overflow-checks = false
 incremental = false
 codegen-units = 16
 
-[profile.dev.package.ring]
-opt-level = 3
-debug-assertions = false
-overflow-checks = false
-incremental = false
-codegen-units = 16
-
-[profile.dev.package.spin]
-opt-level = 3
-debug-assertions = false
-overflow-checks = false
-incremental = false
-codegen-units = 16
-
-[profile.dev.package.untrusted]
-opt-level = 3
-debug-assertions = false
-overflow-checks = false
-incremental = false
-codegen-units = 16
-
 [profile.dev.package.bitvec]
 opt-level = 3
 debug-assertions = false
 overflow-checks = false
 incremental = false
 codegen-units = 16
-
 
 [profile.release]
 panic = "abort"
@@ -295,6 +261,6 @@ debug = false
 [workspace.lints.rust]
 # The linter should ignore these expected config flags/values
 unexpected_cfgs = { level = "warn", check-cfg = [
-    'cfg(tokio_unstable)', # Used by tokio-console
-    'cfg(zcash_unstable, values("zfuture", "nu6.1", "nu7"))' # Used in Zebra and librustzcash
+    'cfg(tokio_unstable)',                                    # Used by tokio-console
+    'cfg(zcash_unstable, values("zfuture", "nu6.1", "nu7"))', # Used in Zebra and librustzcash
 ] }

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -133,6 +133,7 @@ rand = { workspace = true, optional = true }
 rand_chacha = { workspace = true, optional = true }
 
 zebra-test = { path = "../zebra-test/", version = "2.0.1", optional = true }
+zcash_tachyon = { git = "http://github.com/tachyon-zcash/tachyon", rev = "1ff9b78", version = "0.0.0" }
 
 [dev-dependencies]
 # Benchmarks

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -133,7 +133,8 @@ rand = { workspace = true, optional = true }
 rand_chacha = { workspace = true, optional = true }
 
 zebra-test = { path = "../zebra-test/", version = "2.0.1", optional = true }
-zcash_tachyon = { git = "http://github.com/tachyon-zcash/tachyon", rev = "1ff9b78", version = "0.0.0" }
+#zcash_tachyon = { git = "http://github.com/tachyon-zcash/tachyon", rev = "1ff9b78", version = "0.0.0" }
+zcash_tachyon = {path = "../../tachyon/crates/tachyon"}
 
 [dev-dependencies]
 # Benchmarks

--- a/zebra-chain/src/lib.rs
+++ b/zebra-chain/src/lib.rs
@@ -37,6 +37,7 @@ pub mod serialization;
 pub mod shutdown;
 pub mod sprout;
 pub mod subtree;
+pub mod tachyon;
 pub mod transaction;
 pub mod transparent;
 pub mod value_balance;

--- a/zebra-chain/src/primitives/zcash_primitives.rs
+++ b/zebra-chain/src/primitives/zcash_primitives.rs
@@ -142,6 +142,7 @@ impl zp_tx::Authorization for PrecomputedAuth {
     type TransparentAuth = TransparentAuth;
     type SaplingAuth = sapling_crypto::bundle::Authorized;
     type OrchardAuth = orchard::bundle::Authorized;
+    type TachyonAuth = zcash_tachyon::BindingSignature;
 
     #[cfg(zcash_unstable = "zfuture")]
     type TzeAuth = zp_tx::components::tze::Authorized;
@@ -291,6 +292,12 @@ impl PrecomputedTxData {
         &self,
     ) -> Option<sapling_crypto::Bundle<sapling_crypto::bundle::Authorized, ZatBalance>> {
         self.tx_data.sapling_bundle().cloned()
+    }
+
+    pub fn tachyon_bundle(
+        &self
+    ) -> Option<zcash_tachyon::Bundle<ZatBalance>> {
+        self.tx_data.tachyon_bundle().cloned()
     }
 }
 

--- a/zebra-chain/src/tachyon.rs
+++ b/zebra-chain/src/tachyon.rs
@@ -1,0 +1,49 @@
+//! Tachyon-related functionality.
+//!
+//! Tachyon is a scaling solution for Zcash that introduces:
+//! - Tachygrams: Unified 32-byte blobs (nullifiers or note commitments)
+//! - Actions: Spend/output operations with cv, rk, and signature
+//! - Stamps: Proof + tachygrams + anchor
+//! - Aggregate proof transactions via Ragu PCD
+//! - Out-of-band payment distribution (no ciphertexts on-chain)
+//!
+//! ## Type Structure
+//!
+//! ```text
+//! ShieldedData
+//! ├── value_balance: Amount
+//! ├── actions: Vec<Action>
+//! │   └── Action
+//! │       ├── cv: ValueCommitment
+//! │       ├── rk: RandomizedVerificationKey
+//! │       └── sig: SpendAuthSignature
+//! ├── binding_sig: Option<BindingSignature>
+//! └── stamp: Option<Stamp>
+//!     └── Stamp
+//!         ├── tachygrams: Vec<Tachygram>
+//!         ├── proof: Proof
+//!         └── anchor: Anchor
+//! ```
+//!
+//! ## Crate Organization
+//!
+//! Protocol types are re-exported from the `tachyon` crate. The only
+//! zebra-specific type is [`ShieldedData`] (bundle with runtime stamp
+//! optionality and serde).
+
+#![warn(missing_docs)]
+
+#[cfg(any(test, feature = "proptest-impl"))]
+mod arbitrary;
+
+pub mod shielded_data;
+
+// Re-export protocol types from tachyon crate
+pub use zcash_tachyon::{
+    Action, Anchor, BindingSignature, BindingVerificationKey, Epoch, Proof,
+    RandomizedVerificationKey, SpendAuthSignature, Stamp, Tachygram,
+};
+pub use zcash_tachyon::value::Commitment as ValueCommitment;
+
+// Zebra-specific types
+pub use shielded_data::ShieldedData;

--- a/zebra-chain/src/tachyon/arbitrary.rs
+++ b/zebra-chain/src/tachyon/arbitrary.rs
@@ -25,7 +25,7 @@ impl Arbitrary for ShieldedData {
             .prop_map(|(actions, vb, stamp)| {
                 let value_balance = Amount::try_from(vb % 1000).unwrap_or_else(|_| Amount::zero());
                 let binding_sig = if !actions.is_empty() {
-                    Some(tachyon::BindingSignature::from([0u8; 64]))
+                    Some(zcash_tachyon::BindingSignature::from([0u8; 64]))
                 } else {
                     None
                 };
@@ -40,7 +40,7 @@ impl Arbitrary for ShieldedData {
     }
 }
 
-fn arb_action() -> impl Strategy<Value = tachyon::Action> {
+fn arb_action() -> impl Strategy<Value = zcash_tachyon::Action> {
     (any::<bool>(), any::<[u8; 32]>(), any::<[u8; 64]>()).prop_map(
         |(use_identity, rk_bytes, sig_bytes)| {
             let cv = if use_identity {
@@ -49,31 +49,31 @@ fn arb_action() -> impl Strategy<Value = tachyon::Action> {
                 super::ValueCommitment::balance(1)
             };
             // Fallback to a known-good key if random bytes are invalid
-            let rk = tachyon::RandomizedVerificationKey::try_from(rk_bytes).unwrap_or_else(|_| {
-                tachyon::RandomizedVerificationKey::try_from([1u8; 32]).unwrap()
+            let rk = zcash_tachyon::RandomizedVerificationKey::try_from(rk_bytes).unwrap_or_else(|_| {
+                zcash_tachyon::RandomizedVerificationKey::try_from([1u8; 32]).unwrap()
             });
-            let sig = tachyon::SpendAuthSignature::from(sig_bytes);
-            tachyon::Action { cv, rk, sig }
+            let sig = zcash_tachyon::SpendAuthSignature::from(sig_bytes);
+            zcash_tachyon::Action { cv, rk, sig }
         },
     )
 }
 
-fn arb_stamp() -> impl Strategy<Value = tachyon::Stamp> {
+fn arb_stamp() -> impl Strategy<Value = zcash_tachyon::Stamp> {
     (
         proptest::collection::vec(arb_tachygram(), 0..20),
         arb_anchor(),
     )
-        .prop_map(|(tachygrams, anchor)| tachyon::Stamp {
+        .prop_map(|(tachygrams, anchor)| zcash_tachyon::Stamp {
             tachygrams,
             anchor,
-            proof: tachyon::Proof::default(),
+            proof: zcash_tachyon::Proof::default(),
         })
 }
 
-fn arb_tachygram() -> impl Strategy<Value = tachyon::Tachygram> {
-    any::<u64>().prop_map(|val| tachyon::Tachygram::from(pallas::Base::from(val)))
+fn arb_tachygram() -> impl Strategy<Value = zcash_tachyon::Tachygram> {
+    any::<u64>().prop_map(|val| zcash_tachyon::Tachygram::from(pallas::Base::from(val)))
 }
 
-fn arb_anchor() -> impl Strategy<Value = tachyon::Anchor> {
-    any::<u64>().prop_map(|val| tachyon::Anchor::from(pallas::Base::from(val)))
+fn arb_anchor() -> impl Strategy<Value = zcash_tachyon::Anchor> {
+    any::<u64>().prop_map(|val| zcash_tachyon::Anchor::from(pallas::Base::from(val)))
 }

--- a/zebra-chain/src/tachyon/arbitrary.rs
+++ b/zebra-chain/src/tachyon/arbitrary.rs
@@ -1,0 +1,79 @@
+//! Proptest arbitrary implementations for Tachyon types.
+//!
+//! These implement `Arbitrary` for tachyon crate types (orphan rule is
+//! satisfied because proptest is a dev-dependency) and for zebra's
+//! `ShieldedData`.
+
+use proptest::{arbitrary::any, prelude::*};
+
+use halo2::pasta::pallas;
+
+use crate::amount::Amount;
+
+use super::ShieldedData;
+
+impl Arbitrary for ShieldedData {
+    type Parameters = ();
+    type Strategy = BoxedStrategy<Self>;
+
+    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+        (
+            proptest::collection::vec(arb_action(), 0..5),
+            any::<i64>(),
+            proptest::option::of(arb_stamp()),
+        )
+            .prop_map(|(actions, vb, stamp)| {
+                let value_balance = Amount::try_from(vb % 1000).unwrap_or_else(|_| Amount::zero());
+                let binding_sig = if !actions.is_empty() {
+                    Some(tachyon::BindingSignature::from([0u8; 64]))
+                } else {
+                    None
+                };
+                ShieldedData {
+                    actions,
+                    value_balance,
+                    binding_sig,
+                    stamp,
+                }
+            })
+            .boxed()
+    }
+}
+
+fn arb_action() -> impl Strategy<Value = tachyon::Action> {
+    (any::<bool>(), any::<[u8; 32]>(), any::<[u8; 64]>()).prop_map(
+        |(use_identity, rk_bytes, sig_bytes)| {
+            let cv = if use_identity {
+                super::ValueCommitment::balance(0)
+            } else {
+                super::ValueCommitment::balance(1)
+            };
+            // Fallback to a known-good key if random bytes are invalid
+            let rk = tachyon::RandomizedVerificationKey::try_from(rk_bytes).unwrap_or_else(|_| {
+                tachyon::RandomizedVerificationKey::try_from([1u8; 32]).unwrap()
+            });
+            let sig = tachyon::SpendAuthSignature::from(sig_bytes);
+            tachyon::Action { cv, rk, sig }
+        },
+    )
+}
+
+fn arb_stamp() -> impl Strategy<Value = tachyon::Stamp> {
+    (
+        proptest::collection::vec(arb_tachygram(), 0..20),
+        arb_anchor(),
+    )
+        .prop_map(|(tachygrams, anchor)| tachyon::Stamp {
+            tachygrams,
+            anchor,
+            proof: tachyon::Proof::default(),
+        })
+}
+
+fn arb_tachygram() -> impl Strategy<Value = tachyon::Tachygram> {
+    any::<u64>().prop_map(|val| tachyon::Tachygram::from(pallas::Base::from(val)))
+}
+
+fn arb_anchor() -> impl Strategy<Value = tachyon::Anchor> {
+    any::<u64>().prop_map(|val| tachyon::Anchor::from(pallas::Base::from(val)))
+}

--- a/zebra-chain/src/tachyon/shielded_data.rs
+++ b/zebra-chain/src/tachyon/shielded_data.rs
@@ -20,7 +20,7 @@ use crate::amount::{Amount, NegativeAllowed};
 ///
 /// Uses tachyon crate types directly. Serde is implemented at the bundle
 /// level — individual tachyon types do not carry serde derives.
-#[derive(Clone)]
+#[derive(Clone, Eq, PartialEq)]
 pub struct ShieldedData {
     /// The actions (cv, rk, sig for each).
     pub actions: Vec<zcash_tachyon::Action>,

--- a/zebra-chain/src/tachyon/shielded_data.rs
+++ b/zebra-chain/src/tachyon/shielded_data.rs
@@ -1,0 +1,228 @@
+//! Tachyon shielded data for transactions.
+//!
+//! [`ShieldedData`] is the zebra-chain representation of a Tachyon bundle,
+//! using tachyon crate types directly for its fields. Serde is implemented
+//! at the bundle level via a proxy struct pattern.
+//!
+//! ## Stamp optionality
+//!
+//! A bundle's stamp is `Option<Stamp>`:
+//! - `Some`: bundle carries its own proof and tachygrams
+//! - `None`: stamp was stripped and merged into another bundle in the same block
+
+use std::fmt;
+
+use halo2::pasta::{group::ff::PrimeField, pallas};
+
+use crate::amount::{Amount, NegativeAllowed};
+
+/// Tachyon shielded data bundle for a transaction.
+///
+/// Uses tachyon crate types directly. Serde is implemented at the bundle
+/// level — individual tachyon types do not carry serde derives.
+#[derive(Clone)]
+pub struct ShieldedData {
+    /// The actions (cv, rk, sig for each).
+    pub actions: Vec<zcash_tachyon::Action>,
+
+    /// Net value of Tachyon spends minus outputs.
+    pub value_balance: Amount<NegativeAllowed>,
+
+    /// Binding signature on transaction sighash.
+    /// None when actions is empty (nothing to sign over).
+    pub binding_sig: Option<zcash_tachyon::BindingSignature>,
+
+    /// The stamp containing tachygrams, anchor, and proof.
+    /// None after stripping during aggregation.
+    pub stamp: Option<zcash_tachyon::Stamp>,
+}
+
+impl fmt::Debug for ShieldedData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut debug = f.debug_struct("Tachyon ShieldedData");
+        debug
+            .field("actions", &self.actions.len())
+            .field("value_balance", &self.value_balance);
+
+        if let Some(ref stamp) = self.stamp {
+            debug.field("stamp", &format!("{} tachygrams", stamp.tachygrams.len()));
+        } else {
+            debug.field("stamp", &"None (stripped)");
+        }
+
+        debug.finish()
+    }
+}
+
+impl fmt::Display for ShieldedData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(self, f)
+    }
+}
+
+impl ShieldedData {
+    /// Iterate over the actions in this bundle.
+    pub fn actions(&self) -> impl Iterator<Item = &zcash_tachyon::Action> {
+        self.actions.iter()
+    }
+
+    /// Get the value balance of this bundle.
+    pub fn value_balance(&self) -> Amount<NegativeAllowed> {
+        self.value_balance
+    }
+
+    /// Count the number of actions in this bundle.
+    pub fn actions_count(&self) -> usize {
+        self.actions.len()
+    }
+
+    /// Calculate the binding verification key.
+    ///
+    /// `bvk = sum(cv_i) - [value_balance] V`
+    ///
+    /// Follows Orchard's `binding_validating_key()` pattern. The binding
+    /// signature proves that the signer knew all value commitment trapdoors,
+    /// which transitively proves value balance integrity.
+    /// Returns None if there are no actions.
+    pub fn binding_verification_key(&self) -> Option<zcash_tachyon::BindingVerificationKey> {
+        if self.actions.is_empty() {
+            return None;
+        }
+
+        Some(zcash_tachyon::BindingVerificationKey::derive(
+            &self.actions,
+            self.value_balance.into(),
+        ))
+    }
+}
+
+// =============================================================================
+// Serde — implemented at the bundle level via proxy structs
+// =============================================================================
+
+use serde_big_array::BigArray;
+
+/// Serde proxy for a single Action.
+#[derive(Serialize, Deserialize)]
+struct ActionProxy {
+    cv: [u8; 32],
+    rk: [u8; 32],
+    #[serde(with = "BigArray")]
+    sig: [u8; 64],
+}
+
+impl From<zcash_tachyon::Action> for ActionProxy {
+    fn from(a: zcash_tachyon::Action) -> Self {
+        ActionProxy {
+            cv: a.cv.into(),
+            rk: a.rk.into(),
+            sig: a.sig.into(),
+        }
+    }
+}
+
+/// Serde proxy for a Stamp.
+#[derive(Serialize, Deserialize)]
+struct StampProxy {
+    tachygrams: Vec<[u8; 32]>,
+    anchor: [u8; 32],
+    #[serde(with = "BigArray")]
+    proof: [u8; 192],
+}
+
+/// Serde proxy for ShieldedData.
+#[derive(Serialize, Deserialize)]
+struct ShieldedDataProxy {
+    actions: Vec<ActionProxy>,
+    value_balance: Amount<NegativeAllowed>,
+    binding_sig: Option<BindingSigBytes>,
+    stamp: Option<StampProxy>,
+}
+
+/// Wrapper for binding signature bytes with serde support.
+#[derive(Serialize, Deserialize)]
+struct BindingSigBytes(#[serde(with = "BigArray")] [u8; 64]);
+
+impl serde::Serialize for ShieldedData {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let proxy = ShieldedDataProxy {
+            actions: self.actions.iter().map(|a| ActionProxy::from(*a)).collect(),
+            value_balance: self.value_balance,
+            binding_sig: self
+                .binding_sig
+                .as_ref()
+                .map(|s| BindingSigBytes(<[u8; 64]>::from(*s))),
+            stamp: self.stamp.as_ref().map(|s| StampProxy {
+                tachygrams: s
+                    .tachygrams
+                    .iter()
+                    .map(|tg| pallas::Base::from(*tg).to_repr())
+                    .collect(),
+                anchor: pallas::Base::from(s.anchor).to_repr(),
+                proof: {
+                    let bytes: [u8; 192] = s.proof.into();
+                    bytes
+                },
+            }),
+        };
+        proxy.serialize(serializer)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for ShieldedData {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let proxy = ShieldedDataProxy::deserialize(deserializer)?;
+
+        let actions = proxy
+            .actions
+            .into_iter()
+            .map(|a| {
+                let cv = zcash_tachyon::value::Commitment::try_from(&a.cv)
+                    .map_err(serde::de::Error::custom)?;
+                let rk = zcash_tachyon::RandomizedVerificationKey::try_from(a.rk)
+                    .map_err(serde::de::Error::custom)?;
+                let sig = zcash_tachyon::SpendAuthSignature::from(a.sig);
+                Ok(zcash_tachyon::Action { cv, rk, sig })
+            })
+            .collect::<Result<Vec<_>, D::Error>>()?;
+
+        let binding_sig = proxy
+            .binding_sig
+            .map(|b| zcash_tachyon::BindingSignature::from(b.0));
+
+        let stamp = proxy
+            .stamp
+            .map(|s| {
+                let tachygrams = s
+                    .tachygrams
+                    .into_iter()
+                    .map(|bytes| {
+                        <Option<pallas::Base>>::from(pallas::Base::from_repr(bytes))
+                            .map(|fp| zcash_tachyon::Tachygram::from(fp))
+                            .ok_or_else(|| serde::de::Error::custom("invalid field element"))
+                    })
+                    .collect::<Result<Vec<_>, D::Error>>()?;
+
+                let anchor = <Option<pallas::Base>>::from(pallas::Base::from_repr(s.anchor))
+                    .map(|fp| zcash_tachyon::Anchor::from(fp))
+                    .ok_or_else(|| serde::de::Error::custom("invalid field element"))?;
+
+                let proof =
+                    zcash_tachyon::Proof::try_from(&s.proof).map_err(serde::de::Error::custom)?;
+
+                Ok(zcash_tachyon::Stamp {
+                    tachygrams,
+                    anchor,
+                    proof,
+                })
+            })
+            .transpose()?;
+
+        Ok(ShieldedData {
+            actions,
+            value_balance: proxy.value_balance,
+            binding_sig,
+            stamp,
+        })
+    }
+}

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -52,7 +52,6 @@ use crate::{
     sapling,
     serialization::ZcashSerialize,
     sprout,
-    tachyon,
     transparent::{
         self, outputs_from_utxos,
         CoinbaseSpendRestriction::{self, *},
@@ -60,6 +59,9 @@ use crate::{
     value_balance::{ValueBalance, ValueBalanceError},
     Error,
 };
+
+#[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
+use crate::tachyon;
 
 /// A Zcash transaction.
 ///
@@ -1822,6 +1824,7 @@ impl Transaction {
             } => None,
         }
     }
+
 
     /// Modify the transparent outputs of this transaction, regardless of version.
     pub fn outputs_mut(&mut self) -> &mut Vec<transparent::Output> {

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -52,6 +52,7 @@ use crate::{
     sapling,
     serialization::ZcashSerialize,
     sprout,
+    tachyon,
     transparent::{
         self, outputs_from_utxos,
         CoinbaseSpendRestriction::{self, *},
@@ -171,6 +172,8 @@ pub enum Transaction {
         sapling_shielded_data: Option<sapling::ShieldedData<sapling::SharedAnchor>>,
         /// The orchard data for this transaction, if any.
         orchard_shielded_data: Option<orchard::ShieldedData>,
+        /// The tachyon data for this transaction, if any.
+        tachyon_shielded_data: Option<tachyon::ShieldedData>,
     },
 }
 

--- a/zebra-chain/src/transaction/builder.rs
+++ b/zebra-chain/src/transaction/builder.rs
@@ -101,6 +101,7 @@ impl Transaction {
             // See the Zcash spec for additional shielded coinbase consensus rules.
             sapling_shielded_data: None,
             orchard_shielded_data: None,
+            tachyon_shielded_data: None,
         }
     }
 

--- a/zebra-chain/src/transaction/serialize.rs
+++ b/zebra-chain/src/transaction/serialize.rs
@@ -852,6 +852,7 @@ impl ZcashSerialize for Transaction {
                 outputs,
                 sapling_shielded_data,
                 orchard_shielded_data,
+                tachyon_shielded_data
             } => {
                 // Transaction V6 spec:
                 // https://zips.z.cash/zip-0230#specification
@@ -891,6 +892,8 @@ impl ZcashSerialize for Transaction {
                 // `flagsOrchard`,`valueBalanceOrchard`, `anchorOrchard`, `sizeProofsOrchard`,
                 // `proofsOrchard`, `vSpendAuthSigsOrchard`, and `bindingSigOrchard`.
                 orchard_shielded_data.zcash_serialize(&mut writer)?;
+
+                tachyon_shielded_data.zcash_serialize(&mut writer)?;
             }
         }
         Ok(())
@@ -1181,6 +1184,8 @@ impl ZcashDeserialize for Transaction {
                 // `proofsOrchard`, `vSpendAuthSigsOrchard`, and `bindingSigOrchard`.
                 let orchard_shielded_data = (&mut limited_reader).zcash_deserialize_into()?;
 
+                let tachyon_shielded_data = (&mut limited_reader).zcash_deserialize_into()?;
+
                 Ok(Transaction::V6 {
                     network_upgrade,
                     lock_time,
@@ -1190,6 +1195,7 @@ impl ZcashDeserialize for Transaction {
                     outputs,
                     sapling_shielded_data,
                     orchard_shielded_data,
+                    tachyon_shielded_data
                 })
             }
             (_, _) => Err(SerializationError::Parse("bad tx header")),

--- a/zebra-chain/src/transaction/serialize.rs
+++ b/zebra-chain/src/transaction/serialize.rs
@@ -4,7 +4,10 @@
 use std::{borrow::Borrow, io, sync::Arc};
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
-use halo2::pasta::group::ff::PrimeField;
+use halo2::pasta::{
+    group::ff::PrimeField,
+    pallas,
+};
 use hex::FromHex;
 use reddsa::{orchard::Binding, orchard::SpendAuth, Signature};
 
@@ -14,10 +17,12 @@ use crate::{
     parameters::{OVERWINTER_VERSION_GROUP_ID, SAPLING_VERSION_GROUP_ID, TX_V5_VERSION_GROUP_ID},
     primitives::{Halo2Proof, ZkSnarkProof},
     serialization::{
-        zcash_deserialize_external_count, zcash_serialize_empty_list,
-        zcash_serialize_external_count, AtLeastOne, ReadZcashExt, SerializationError,
-        TrustedPreallocate, ZcashDeserialize, ZcashDeserializeInto, ZcashSerialize,
+        zcash_deserialize_external_count, zcash_serialize_bytes, zcash_serialize_empty_list,
+        zcash_serialize_external_count, AtLeastOne, CompactSizeMessage, ReadZcashExt,
+        SerializationError, TrustedPreallocate, ZcashDeserialize, ZcashDeserializeInto,
+        ZcashSerialize,
     },
+    tachyon,
 };
 
 #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
@@ -463,6 +468,167 @@ impl<T: reddsa::SigType> ZcashSerialize for reddsa::Signature<T> {
 impl<T: reddsa::SigType> ZcashDeserialize for reddsa::Signature<T> {
     fn zcash_deserialize<R: io::Read>(mut reader: R) -> Result<Self, SerializationError> {
         Ok(reader.read_64_bytes()?.into())
+    }
+}
+
+// Tachyon ShieldedData serialization
+//
+// Wire format (counts first, conditional fields):
+//
+// nTachygrams    : compactsize (0 if stripped)
+// nActions       : compactsize
+// vActions       : nActions × 128 bytes     (if nActions > 0)
+// valueBalance   : i64                      (if nActions > 0)
+// bindingSig     : 64 bytes                 (if nActions > 0)
+// anchor         : 32 bytes                 (if nTachygrams > 0)
+// vTachygrams    : nTachygrams × 32 bytes   (if nTachygrams > 0)
+// proof          : size-prefixed bytes      (if nTachygrams > 0)
+//
+// Bundle categories based on counts:
+// - None:      nTachygrams = 0, nActions = 0
+// - Adjunct:   nTachygrams = 0, nActions > 0 (stripped)
+// - Autonome:  nTachygrams = nActions > 0 (self-contained)
+// - Aggregate: nTachygrams > nActions (carries others' tachygrams)
+//   - Based:    nActions > 0 ("based" = coinbase, miner shielding rewards)
+//   - Innocent: nActions = 0 (only carries tachystamps)
+
+impl ZcashSerialize for Option<tachyon::ShieldedData> {
+    fn zcash_serialize<W: io::Write>(&self, mut writer: W) -> Result<(), io::Error> {
+        match self {
+            None => {
+                // Empty tachyon data: nTachygrams = 0, nActions = 0
+                zcash_serialize_empty_list(&mut writer)?;
+                zcash_serialize_empty_list(writer)?;
+            }
+            Some(tachyon_shielded_data) => {
+                tachyon_shielded_data.zcash_serialize(&mut writer)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl ZcashSerialize for tachyon::ShieldedData {
+    fn zcash_serialize<W: io::Write>(&self, mut writer: W) -> Result<(), io::Error> {
+        // Counts first
+        let n_tachygrams = self.stamp.as_ref().map(|s| s.tachygrams.len()).unwrap_or(0); // 0 if stripped
+        CompactSizeMessage::try_from(n_tachygrams)?.zcash_serialize(&mut writer)?;
+        CompactSizeMessage::try_from(self.actions.len())?.zcash_serialize(&mut writer)?;
+
+        // Action fields (conditional on nActions > 0)
+        if !self.actions.is_empty() {
+            for action in self.actions.iter() {
+                let cv_bytes: [u8; 32] = action.cv.into();
+                let rk_bytes: [u8; 32] = action.rk.into();
+                let sig_bytes: [u8; 64] = action.sig.into();
+                writer.write_all(&cv_bytes)?; // cv: 32 bytes
+                writer.write_all(&rk_bytes)?; // rk: 32 bytes
+                writer.write_all(&sig_bytes)?; // sig: 64 bytes
+            }
+            self.value_balance.zcash_serialize(&mut writer)?;
+            // binding_sig must be Some when actions is non-empty
+            let binding_sig = self
+                .binding_sig
+                .expect("binding_sig required when actions present");
+            writer.write_all(&<[u8; 64]>::from(binding_sig))?;
+        }
+
+        // Stamp fields at end (stripped in adjuncts)
+        if let Some(stamp) = &self.stamp {
+            writer.write_all(&pallas::Base::from(stamp.anchor).to_repr())?; // anchor: 32 bytes
+            for tg in &stamp.tachygrams {
+                writer.write_all(&pallas::Base::from(*tg).to_repr())?; // tachygram: 32 bytes each
+            }
+            // proof: size-prefixed (placeholder — empty for now)
+            zcash_serialize_bytes(&Vec::new(), &mut writer)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl ZcashDeserialize for Option<tachyon::ShieldedData> {
+    fn zcash_deserialize<R: io::Read>(mut reader: R) -> Result<Self, SerializationError> {
+        // Counts first
+        let n_tachygrams: usize = (&mut reader)
+            .zcash_deserialize_into::<CompactSizeMessage>()?
+            .into();
+        let n_actions: usize = (&mut reader)
+            .zcash_deserialize_into::<CompactSizeMessage>()?
+            .into();
+
+        if n_tachygrams == 0 && n_actions == 0 {
+            return Ok(None);
+        }
+
+        // Action fields (conditional on nActions > 0)
+        let (actions, value_balance, binding_sig) = if n_actions > 0 {
+            let mut actions = Vec::with_capacity(n_actions);
+            for _ in 0..n_actions {
+                let cv_bytes: [u8; 32] = reader.read_32_bytes()?;
+
+                let cv = tachyon::ValueCommitment::try_from(&cv_bytes)
+                    .map_err(|_| SerializationError::Parse("Invalid ValueCommitment in action"))?;
+
+                let rk_bytes: [u8; 32] = reader.read_32_bytes()?;
+                let rk = tachyon::RandomizedVerificationKey::try_from(rk_bytes)
+                    .map_err(|_| SerializationError::Parse("Invalid verification key in action"))?;
+
+                let sig_bytes: [u8; 64] = reader.read_64_bytes()?;
+                let sig = tachyon::SpendAuthSignature::from(sig_bytes);
+
+                actions.push(tachyon::Action { cv, rk, sig });
+            }
+
+            let value_balance: amount::Amount = (&mut reader).zcash_deserialize_into()?;
+            let binding_sig_bytes: [u8; 64] = reader.read_64_bytes()?;
+            let binding_sig = tachyon::BindingSignature::from(binding_sig_bytes);
+
+            (actions, value_balance, Some(binding_sig))
+        } else {
+            // Pure aggregate: no actions, no value flow, no binding sig
+            (Vec::new(), amount::Amount::zero(), None)
+        };
+
+        // Stamp fields at end (if present)
+        let stamp = if n_tachygrams > 0 {
+            // anchor: 32 bytes
+            let anchor_bytes: [u8; 32] = reader.read_32_bytes()?;
+            let anchor = <Option<pallas::Base>>::from(pallas::Base::from_repr(anchor_bytes))
+                .map(tachyon::Anchor::from)
+                .ok_or(SerializationError::Parse("Invalid field element in anchor"))?;
+
+            // vTachygrams: n × 32 bytes
+            let mut tachygrams = Vec::with_capacity(n_tachygrams);
+            for _ in 0..n_tachygrams {
+                let bytes: [u8; 32] = reader.read_32_bytes()?;
+                let tg = <Option<pallas::Base>>::from(pallas::Base::from_repr(bytes))
+                    .map(tachyon::Tachygram::from)
+                    .ok_or(SerializationError::Parse(
+                        "Invalid field element in tachygram",
+                    ))?;
+                tachygrams.push(tg);
+            }
+
+            // proof: size-prefixed (placeholder — read and discard)
+            let _proof_bytes: Vec<u8> = (&mut reader).zcash_deserialize_into()?;
+            let proof = tachyon::Proof::default();
+
+            Some(tachyon::Stamp {
+                tachygrams,
+                proof,
+                anchor,
+            })
+        } else {
+            None
+        };
+
+        Ok(Some(tachyon::ShieldedData {
+            actions,
+            value_balance,
+            binding_sig,
+            stamp,
+        }))
     }
 }
 

--- a/zebra-chain/src/transaction/sighash.rs
+++ b/zebra-chain/src/transaction/sighash.rs
@@ -137,4 +137,10 @@ impl SigHasher {
     ) -> Option<sapling_crypto::Bundle<sapling_crypto::bundle::Authorized, ZatBalance>> {
         self.precomputed_tx_data.sapling_bundle()
     }
+
+    pub fn tachyon_bundle(
+        &self,
+    ) -> Option<zcash_tachyon::Bundle<ZatBalance>> {
+        None
+    }
 }

--- a/zebra-consensus/src/block.rs
+++ b/zebra-consensus/src/block.rs
@@ -227,13 +227,9 @@ where
                 .map_err(VerifyBlockError::Time)?;
             let coinbase_tx = check::coinbase_is_first(&block)?;
             
-            // Check tachyon aggregation rules
+            // Validate and verify tachyon aggregate proofs
             #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
-            check::coinbase_has_tachyon_aggregate(&block)?;
-
-            // Verify tachyon aggregate proof
-            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
-            check::verify_tachyon_aggregate(&block)?;
+            check::verify_tachyon_aggregates(&block)?;
 
             let expected_block_subsidy =
                 zebra_chain::parameters::subsidy::block_subsidy(height, &network)?;

--- a/zebra-consensus/src/block.rs
+++ b/zebra-consensus/src/block.rs
@@ -231,6 +231,10 @@ where
             #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
             check::coinbase_has_tachyon_aggregate(&block)?;
 
+            // Verify tachyon aggregate proof
+            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
+            check::verify_tachyon_aggregate(&block)?;
+
             let expected_block_subsidy =
                 zebra_chain::parameters::subsidy::block_subsidy(height, &network)?;
 

--- a/zebra-consensus/src/block.rs
+++ b/zebra-consensus/src/block.rs
@@ -226,6 +226,10 @@ where
             check::time_is_valid_at(&block.header, now, &height, &hash)
                 .map_err(VerifyBlockError::Time)?;
             let coinbase_tx = check::coinbase_is_first(&block)?;
+            
+            // Check tachyon aggregation rules
+            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
+            check::coinbase_has_tachyon_aggregate(&block)?;
 
             let expected_block_subsidy =
                 zebra_chain::parameters::subsidy::block_subsidy(height, &network)?;

--- a/zebra-consensus/src/block/check.rs
+++ b/zebra-consensus/src/block/check.rs
@@ -68,91 +68,15 @@ pub fn coinbase_is_first(block: &Block) -> Result<Arc<transaction::Transaction>,
     Ok(first.clone())
 }
 
-/// Checks tachyon aggregation rules for blocks with tachyon transactions.
+/// Validates and verifies all tachyon aggregate proofs in the block.
 /// 
-/// Enforces that every sequence of unstamped tachyon transactions must be followed
-/// by a stamped transaction that aggregates their actions. Stamped transactions
-/// have tachyon_shielded_data.stamp = Some(...), unstamped have stamp = None.
+/// This function combines structural validation and cryptographic verification:
+/// 1. Ensures every sequence of unstamped tachyon transactions is followed by a stamped transaction
+/// 2. For each stamped transaction, verifies its proof against actions from itself and following unstamped transactions
 ///
-/// Returns `Ok(())` if the tachyon aggregation rules are satisfied.
+/// Returns `Ok(())` if all tachyon aggregation rules are satisfied and proofs verify.
 #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
-pub fn coinbase_has_tachyon_aggregate(block: &Block) -> Result<(), BlockError> {
-    use zebra_chain::transaction::Transaction;
-    
-    let transactions = &block.transactions;
-    let mut i = 0;
-    
-    while i < transactions.len() {
-        let tx = &transactions[i];
-        
-        // Check if this transaction has tachyon data
-        if let Transaction::V6 { tachyon_shielded_data: Some(tachyon_data), .. } = tx.as_ref() {
-            if tachyon_data.stamp.is_some() {
-                // This is a stamped transaction - continue to next transaction
-                i += 1;
-                continue;
-            }
-            
-            // This is an unstamped transaction - find the next stamped transaction
-            let mut unstamped_count = 0;
-            let mut j = i;
-            
-            // Count consecutive unstamped tachyon transactions
-            while j < transactions.len() {
-                if let Transaction::V6 { tachyon_shielded_data: Some(data), .. } = transactions[j].as_ref() {
-                    if data.stamp.is_some() {
-                        // Found a stamped transaction
-                        break;
-                    }
-                    unstamped_count += 1;
-                } else {
-                    // Non-tachyon transaction, skip
-                }
-                j += 1;
-            }
-            
-            // Ensure we found a stamped transaction after unstamped ones
-            if unstamped_count > 0 {
-                if j >= transactions.len() {
-                    return Err(BlockError::Other(
-                        "Unstamped tachyon transactions must be followed by a stamped transaction".to_string()
-                    ));
-                }
-                
-                // Verify the stamped transaction at position j exists
-                if let Transaction::V6 { tachyon_shielded_data: Some(data), .. } = transactions[j].as_ref() {
-                    if data.stamp.is_none() {
-                        return Err(BlockError::Other(
-                            "Expected stamped transaction after unstamped sequence".to_string()
-                        ));
-                    }
-                } else {
-                    return Err(BlockError::Other(
-                        "Expected stamped tachyon transaction after unstamped sequence".to_string()
-                    ));
-                }
-            }
-            
-            // Move to the stamped transaction
-            i = j + 1;
-        } else {
-            // Non-tachyon transaction, continue
-            i += 1;
-        }
-    }
-    
-    Ok(())
-}
-
-/// Cryptographically verifies all tachyon aggregate proofs in the block.
-/// 
-/// For each stamped transaction, this function calls `verify()` on its proof,
-/// using tachygrams from the stamp and actions from all unstamped transactions
-/// following its position up to the next stamped transaction.
-///
-/// Returns `Ok(())` if all proof verifications succeed.
-#[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
-pub fn verify_tachyon_aggregate(block: &Block) -> Result<(), BlockError> {
+pub fn verify_tachyon_aggregates(block: &Block) -> Result<(), BlockError> {
     use zebra_chain::transaction::Transaction;
     use zebra_chain::tachyon::{Action, Tachygram, Anchor};
     
@@ -160,10 +84,10 @@ pub fn verify_tachyon_aggregate(block: &Block) -> Result<(), BlockError> {
     let mut i = 0;
     
     while i < transactions.len() {
-        // Find stamped transactions
+        // Check if this transaction has tachyon data
         if let Transaction::V6 { tachyon_shielded_data: Some(tachyon_data), .. } = transactions[i].as_ref() {
             if let Some(stamp) = &tachyon_data.stamp {
-                // This is a stamped transaction - collect actions from following unstamped transactions
+                // This is a stamped transaction - collect actions and verify proof
                 let mut actions_to_verify = Vec::<Action>::new();
                 
                 // Include actions from the stamped transaction itself
@@ -196,8 +120,29 @@ pub fn verify_tachyon_aggregate(block: &Block) -> Result<(), BlockError> {
                 // Move past the unstamped transactions we just processed
                 i = j;
             } else {
-                // Unstamped transaction, continue
-                i += 1;
+                // This is an unstamped transaction - find the next stamped transaction
+                let mut j = i;
+                
+                // Skip consecutive unstamped tachyon transactions
+                while j < transactions.len() {
+                    if let Transaction::V6 { tachyon_shielded_data: Some(data), .. } = transactions[j].as_ref() {
+                        if data.stamp.is_some() {
+                            // Found a stamped transaction
+                            break;
+                        }
+                    }
+                    j += 1;
+                }
+                
+                // Ensure we found a stamped transaction after unstamped ones
+                if j >= transactions.len() {
+                    return Err(BlockError::Other(
+                        "Unstamped tachyon transactions must be followed by a stamped transaction".to_string()
+                    ));
+                }
+                
+                // Move to the stamped transaction (it will be processed in next iteration)
+                i = j;
             }
         } else {
             // Non-tachyon transaction, continue

--- a/zebra-consensus/src/block/check.rs
+++ b/zebra-consensus/src/block/check.rs
@@ -68,6 +68,64 @@ pub fn coinbase_is_first(block: &Block) -> Result<Arc<transaction::Transaction>,
     Ok(first.clone())
 }
 
+/// Checks tachyon aggregation rules for blocks with tachyon transactions.
+/// 
+/// Enforces that if the block contains any non-coinbase transactions with tachyon_shielded_data,
+/// then those transactions must have their tachyon_shielded_data.stamp == None (stripped).
+/// The coinbase transaction MUST have its tachyon_shielded_data.stamp = Some(...) (aggregated).
+///
+/// Returns `Ok(())` if the tachyon aggregation rules are satisfied.
+#[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
+pub fn coinbase_has_tachyon_aggregate(block: &Block) -> Result<(), BlockError> {
+    use zebra_chain::transaction::Transaction;
+    
+    // Get the coinbase transaction (first transaction)
+    let coinbase_tx = block
+        .transactions
+        .first()
+        .ok_or(BlockError::NoTransactions)?;
+
+    // Check all non-coinbase transactions
+    let non_coinbase_txs = block.transactions.iter().skip(1);
+    
+    // Collect all non-coinbase transactions that have tachyon_shielded_data
+    let mut has_tachyon_non_coinbase = false;
+    for tx in non_coinbase_txs {
+        // Check if this is a V6 transaction with tachyon data
+        if let Transaction::V6 { tachyon_shielded_data: Some(tachyon_data), .. } = tx.as_ref() {
+            has_tachyon_non_coinbase = true;
+            
+            // Non-coinbase transactions with tachyon data MUST have stamp == None
+            if tachyon_data.stamp.is_some() {
+                return Err(BlockError::Other(
+                    "Non-coinbase transaction with tachyon_shielded_data must have stamp == None".to_string()
+                ));
+            }
+        }
+    }
+    
+    // If there are non-coinbase transactions with tachyon data, 
+    // the coinbase MUST have tachyon data with a stamp
+    if has_tachyon_non_coinbase {
+        match coinbase_tx.as_ref() {
+            Transaction::V6 { tachyon_shielded_data: Some(coinbase_tachyon_data), .. } => {
+                if coinbase_tachyon_data.stamp.is_none() {
+                    return Err(BlockError::Other(
+                        "Coinbase transaction must have tachyon_shielded_data.stamp = Some(...) when block contains tachyon transactions".to_string()
+                    ));
+                }
+            }
+            Transaction::V6 { tachyon_shielded_data: None, .. } | _ => {
+                return Err(BlockError::Other(
+                    "Coinbase transaction must have tachyon_shielded_data when block contains tachyon transactions".to_string()
+                ));
+            }
+        }
+    }
+    
+    Ok(())
+}
+
 /// Returns `Ok(ExpandedDifficulty)` if the`difficulty_threshold` of `header` is at least as difficult as
 /// the target difficulty limit for `network` (PoWLimit)
 ///

--- a/zebra-consensus/src/block/check.rs
+++ b/zebra-consensus/src/block/check.rs
@@ -70,56 +70,138 @@ pub fn coinbase_is_first(block: &Block) -> Result<Arc<transaction::Transaction>,
 
 /// Checks tachyon aggregation rules for blocks with tachyon transactions.
 /// 
-/// Enforces that if the block contains any non-coinbase transactions with tachyon_shielded_data,
-/// then those transactions must have their tachyon_shielded_data.stamp == None (stripped).
-/// The coinbase transaction MUST have its tachyon_shielded_data.stamp = Some(...) (aggregated).
+/// Enforces that every sequence of unstamped tachyon transactions must be followed
+/// by a stamped transaction that aggregates their actions. Stamped transactions
+/// have tachyon_shielded_data.stamp = Some(...), unstamped have stamp = None.
 ///
 /// Returns `Ok(())` if the tachyon aggregation rules are satisfied.
 #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
 pub fn coinbase_has_tachyon_aggregate(block: &Block) -> Result<(), BlockError> {
     use zebra_chain::transaction::Transaction;
     
-    // Get the coinbase transaction (first transaction)
-    let coinbase_tx = block
-        .transactions
-        .first()
-        .ok_or(BlockError::NoTransactions)?;
-
-    // Check all non-coinbase transactions
-    let non_coinbase_txs = block.transactions.iter().skip(1);
+    let transactions = &block.transactions;
+    let mut i = 0;
     
-    // Collect all non-coinbase transactions that have tachyon_shielded_data
-    let mut has_tachyon_non_coinbase = false;
-    for tx in non_coinbase_txs {
-        // Check if this is a V6 transaction with tachyon data
+    while i < transactions.len() {
+        let tx = &transactions[i];
+        
+        // Check if this transaction has tachyon data
         if let Transaction::V6 { tachyon_shielded_data: Some(tachyon_data), .. } = tx.as_ref() {
-            has_tachyon_non_coinbase = true;
-            
-            // Non-coinbase transactions with tachyon data MUST have stamp == None
             if tachyon_data.stamp.is_some() {
-                return Err(BlockError::Other(
-                    "Non-coinbase transaction with tachyon_shielded_data must have stamp == None".to_string()
-                ));
+                // This is a stamped transaction - continue to next transaction
+                i += 1;
+                continue;
             }
-        }
-    }
-    
-    // If there are non-coinbase transactions with tachyon data, 
-    // the coinbase MUST have tachyon data with a stamp
-    if has_tachyon_non_coinbase {
-        match coinbase_tx.as_ref() {
-            Transaction::V6 { tachyon_shielded_data: Some(coinbase_tachyon_data), .. } => {
-                if coinbase_tachyon_data.stamp.is_none() {
+            
+            // This is an unstamped transaction - find the next stamped transaction
+            let mut unstamped_count = 0;
+            let mut j = i;
+            
+            // Count consecutive unstamped tachyon transactions
+            while j < transactions.len() {
+                if let Transaction::V6 { tachyon_shielded_data: Some(data), .. } = transactions[j].as_ref() {
+                    if data.stamp.is_some() {
+                        // Found a stamped transaction
+                        break;
+                    }
+                    unstamped_count += 1;
+                } else {
+                    // Non-tachyon transaction, skip
+                }
+                j += 1;
+            }
+            
+            // Ensure we found a stamped transaction after unstamped ones
+            if unstamped_count > 0 {
+                if j >= transactions.len() {
                     return Err(BlockError::Other(
-                        "Coinbase transaction must have tachyon_shielded_data.stamp = Some(...) when block contains tachyon transactions".to_string()
+                        "Unstamped tachyon transactions must be followed by a stamped transaction".to_string()
+                    ));
+                }
+                
+                // Verify the stamped transaction at position j exists
+                if let Transaction::V6 { tachyon_shielded_data: Some(data), .. } = transactions[j].as_ref() {
+                    if data.stamp.is_none() {
+                        return Err(BlockError::Other(
+                            "Expected stamped transaction after unstamped sequence".to_string()
+                        ));
+                    }
+                } else {
+                    return Err(BlockError::Other(
+                        "Expected stamped tachyon transaction after unstamped sequence".to_string()
                     ));
                 }
             }
-            Transaction::V6 { tachyon_shielded_data: None, .. } | _ => {
-                return Err(BlockError::Other(
-                    "Coinbase transaction must have tachyon_shielded_data when block contains tachyon transactions".to_string()
-                ));
+            
+            // Move to the stamped transaction
+            i = j + 1;
+        } else {
+            // Non-tachyon transaction, continue
+            i += 1;
+        }
+    }
+    
+    Ok(())
+}
+
+/// Cryptographically verifies all tachyon aggregate proofs in the block.
+/// 
+/// For each stamped transaction, this function calls `verify()` on its proof,
+/// using tachygrams from the stamp and actions from all unstamped transactions
+/// following its position up to the next stamped transaction.
+///
+/// Returns `Ok(())` if all proof verifications succeed.
+#[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
+pub fn verify_tachyon_aggregate(block: &Block) -> Result<(), BlockError> {
+    use zebra_chain::transaction::Transaction;
+    use zebra_chain::tachyon::{Action, Tachygram, Anchor};
+    
+    let transactions = &block.transactions;
+    let mut i = 0;
+    
+    while i < transactions.len() {
+        // Find stamped transactions
+        if let Transaction::V6 { tachyon_shielded_data: Some(tachyon_data), .. } = transactions[i].as_ref() {
+            if let Some(stamp) = &tachyon_data.stamp {
+                // This is a stamped transaction - collect actions from following unstamped transactions
+                let mut actions_to_verify = Vec::<Action>::new();
+                
+                // Include actions from the stamped transaction itself
+                actions_to_verify.extend_from_slice(&tachyon_data.actions);
+                
+                // Collect actions from unstamped transactions following this stamped one
+                let mut j = i + 1;
+                while j < transactions.len() {
+                    if let Transaction::V6 { tachyon_shielded_data: Some(data), .. } = transactions[j].as_ref() {
+                        if data.stamp.is_some() {
+                            // Found next stamped transaction, stop collecting
+                            break;
+                        }
+                        // This is an unstamped transaction, collect its actions
+                        actions_to_verify.extend_from_slice(&data.actions);
+                    }
+                    j += 1;
+                }
+                
+                // Verify the stamp's proof against collected actions
+                let tachygrams: &[Tachygram] = &stamp.tachygrams;
+                let anchor: Anchor = stamp.anchor;
+                
+                stamp.proof
+                    .verify(&actions_to_verify, tachygrams, anchor)
+                    .map_err(|_| BlockError::Other(
+                        format!("Tachyon aggregate proof verification failed for transaction at position {}", i)
+                    ))?;
+                
+                // Move past the unstamped transactions we just processed
+                i = j;
+            } else {
+                // Unstamped transaction, continue
+                i += 1;
             }
+        } else {
+            // Non-tachyon transaction, continue
+            i += 1;
         }
     }
     


### PR DESCRIPTION
builds on https://github.com/tachyon-zcash/zebra/pull/24

- If a block contains any non-coinbase tachyon transactions, they MUST be stripped of their proofdata. Then, the coinbase transaction MUST have proofdata.
- We verify the aggregate Ragu proof by scraping `Actions` out of non-coinbase transactions, and passing them as inputs to the verifier, along with the tachygrams and anchor from the aggregate.