### PR TITLE
[alternate] Scaffold Tachyon in V6 Transactions

### DIFF
--- a/zebra/.vscode/settings.json
+++ b/zebra/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+    "rust-analyzer.cargo.features": [
+        "tx_v6"
+    ],
+    "rust-analyzer.cargo.cfgs": [
+        "zcash_unstable=nu7"
+    ],
+    "rust-analyzer.cargo.extraEnv": {
+        "RUSTFLAGS": "--cfg zcash_unstable=\"nu7\""
+    }
+}

--- a/zebra/zebra-chain/src/tachyon/action.rs
+++ b/zebra/zebra-chain/src/tachyon/action.rs
@@ -1,2 +1,28 @@
-#[derive(Clone)]
+use crate::serialization::{SerializationError, ZcashDeserialize, ZcashSerialize, TrustedPreallocate};
+use serde::{Deserialize, Serialize};
+use std::io;
+
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct Action {}
+
+impl ZcashSerialize for Action {
+    fn zcash_serialize<W: io::Write>(&self, _writer: W) -> Result<(), io::Error> {
+        // Empty action placeholder - no serialization needed yet
+        Ok(())
+    }
+}
+
+impl ZcashDeserialize for Action {
+    fn zcash_deserialize<R: io::Read>(_reader: R) -> Result<Self, SerializationError> {
+        // Empty action placeholder - no deserialization needed yet
+        Ok(Action {})
+    }
+}
+
+impl TrustedPreallocate for Action {
+    fn max_allocation() -> u64 {
+        // Since Action is currently empty, we set a conservative limit
+        // This can be updated once the Action structure is finalized
+        1000
+    }
+}

--- a/zebra/zebra-chain/src/tachyon/shielded_data.rs
+++ b/zebra/zebra-chain/src/tachyon/shielded_data.rs
@@ -2,7 +2,7 @@ use crate::{
     amount::{Amount, NegativeAllowed},
 };
 
-#[derive(Clone)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct ShieldedData {
     /// The actions (cv, rk, sig for each).
     pub actions: Vec<super::Action>,

--- a/zebra/zebra-chain/src/tachyon/stamp.rs
+++ b/zebra/zebra-chain/src/tachyon/stamp.rs
@@ -1,4 +1,20 @@
-#[derive(Clone)]
-pub struct Stamp {
+use crate::serialization::{SerializationError, ZcashDeserialize, ZcashSerialize};
+use serde::{Deserialize, Serialize};
+use std::io;
 
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+pub struct Stamp {}
+
+impl ZcashSerialize for Stamp {
+    fn zcash_serialize<W: io::Write>(&self, _writer: W) -> Result<(), io::Error> {
+        // Empty stamp placeholder - no serialization needed yet
+        Ok(())
+    }
+}
+
+impl ZcashDeserialize for Stamp {
+    fn zcash_deserialize<R: io::Read>(_reader: R) -> Result<Self, SerializationError> {
+        // Empty stamp placeholder - no deserialization needed yet
+        Ok(Stamp {})
+    }
 }

--- a/zebra/zebra-chain/src/transaction.rs
+++ b/zebra/zebra-chain/src/transaction.rs
@@ -56,6 +56,7 @@ use crate::{
         self, outputs_from_utxos,
         CoinbaseSpendRestriction::{self, *},
     },
+    tachyon,
     value_balance::{ValueBalance, ValueBalanceError},
     Error,
 };
@@ -171,6 +172,8 @@ pub enum Transaction {
         sapling_shielded_data: Option<sapling::ShieldedData<sapling::SharedAnchor>>,
         /// The orchard data for this transaction, if any.
         orchard_shielded_data: Option<orchard::ShieldedData>,
+        /// The tachyon data for this transaction, if any.
+        tachyon_shielded_data: Option<tachyon::ShieldedData>,
     },
 }
 

--- a/zebra/zebra-chain/src/transaction/builder.rs
+++ b/zebra/zebra-chain/src/transaction/builder.rs
@@ -101,6 +101,7 @@ impl Transaction {
             // See the Zcash spec for additional shielded coinbase consensus rules.
             sapling_shielded_data: None,
             orchard_shielded_data: None,
+            tachyon_shielded_data: None,
         }
     }
 


### PR DESCRIPTION
Alternative to the approach in https://github.com/tachyon-zcash/zebra/pull/28

Zebra rarely imports the external orchard crate, instead usually opts to use these minimal and more serialization-friendly re-implementations from `zebra-chain/orchard`. This is fine for orchard, because the shielded protocol has a finalized specification whereas tachyon is under active development.

In this PR, we use the same approach as orchard in zebra, where we mostly re-define the types.

I recommend this approach because:
1. it's much easier to stub
2. serialization is easier
3. it matches the way orchard is imported

The one downside is that we will have to manually bring our zebra types up to date with the tachyon as we iterate on the protocol