### PR TITLE
V6 transaction proptest strategies with tachyon bundles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1550,7 +1550,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.2.2"
-source = "git+https://github.com/S1nus/librustzcash.git?rev=3936d052035e66329f06665f891ebc2a3bc06b09#3936d052035e66329f06665f891ebc2a3bc06b09"
+source = "git+https://github.com/tachyon-zcash/librustzcash.git?rev=ae3a9d465424b3321c4e0809b62b88d26e61e4e4#ae3a9d465424b3321c4e0809b62b88d26e61e4e4"
 dependencies = [
  "blake2b_simd",
  "cc",
@@ -1597,7 +1597,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/S1nus/librustzcash.git?rev=3936d052035e66329f06665f891ebc2a3bc06b09#3936d052035e66329f06665f891ebc2a3bc06b09"
+source = "git+https://github.com/tachyon-zcash/librustzcash.git?rev=ae3a9d465424b3321c4e0809b62b88d26e61e4e4#ae3a9d465424b3321c4e0809b62b88d26e61e4e4"
 dependencies = [
  "blake2b_simd",
 ]
@@ -6545,7 +6545,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.10.1"
-source = "git+https://github.com/S1nus/librustzcash.git?rev=3936d052035e66329f06665f891ebc2a3bc06b09#3936d052035e66329f06665f891ebc2a3bc06b09"
+source = "git+https://github.com/tachyon-zcash/librustzcash.git?rev=ae3a9d465424b3321c4e0809b62b88d26e61e4e4#ae3a9d465424b3321c4e0809b62b88d26e61e4e4"
 dependencies = [
  "bech32",
  "bs58",
@@ -6558,7 +6558,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.3.0"
-source = "git+https://github.com/S1nus/librustzcash.git?rev=3936d052035e66329f06665f891ebc2a3bc06b09#3936d052035e66329f06665f891ebc2a3bc06b09"
+source = "git+https://github.com/tachyon-zcash/librustzcash.git?rev=ae3a9d465424b3321c4e0809b62b88d26e61e4e4#ae3a9d465424b3321c4e0809b62b88d26e61e4e4"
 dependencies = [
  "core2",
  "hex",
@@ -6568,7 +6568,7 @@ dependencies = [
 [[package]]
 name = "zcash_history"
 version = "0.4.0"
-source = "git+https://github.com/S1nus/librustzcash.git?rev=3936d052035e66329f06665f891ebc2a3bc06b09#3936d052035e66329f06665f891ebc2a3bc06b09"
+source = "git+https://github.com/tachyon-zcash/librustzcash.git?rev=ae3a9d465424b3321c4e0809b62b88d26e61e4e4#ae3a9d465424b3321c4e0809b62b88d26e61e4e4"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -6578,7 +6578,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.12.0"
-source = "git+https://github.com/S1nus/librustzcash.git?rev=3936d052035e66329f06665f891ebc2a3bc06b09#3936d052035e66329f06665f891ebc2a3bc06b09"
+source = "git+https://github.com/tachyon-zcash/librustzcash.git?rev=ae3a9d465424b3321c4e0809b62b88d26e61e4e4#ae3a9d465424b3321c4e0809b62b88d26e61e4e4"
 dependencies = [
  "bech32",
  "blake2b_simd",
@@ -6618,7 +6618,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.26.4"
-source = "git+https://github.com/S1nus/librustzcash.git?rev=3936d052035e66329f06665f891ebc2a3bc06b09#3936d052035e66329f06665f891ebc2a3bc06b09"
+source = "git+https://github.com/tachyon-zcash/librustzcash.git?rev=ae3a9d465424b3321c4e0809b62b88d26e61e4e4#ae3a9d465424b3321c4e0809b62b88d26e61e4e4"
 dependencies = [
  "bip32",
  "blake2b_simd",
@@ -6654,7 +6654,7 @@ dependencies = [
  "zcash_protocol",
  "zcash_script",
  "zcash_spec",
- "zcash_tachyon 0.0.0 (git+https://github.com/tachyon-zcash/tachyon.git?rev=a441c0cba73c9accebac324abdbd28b2f9701dd5)",
+ "zcash_tachyon",
  "zcash_transparent",
  "zip32",
 ]
@@ -6662,7 +6662,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.26.1"
-source = "git+https://github.com/S1nus/librustzcash.git?rev=3936d052035e66329f06665f891ebc2a3bc06b09#3936d052035e66329f06665f891ebc2a3bc06b09"
+source = "git+https://github.com/tachyon-zcash/librustzcash.git?rev=ae3a9d465424b3321c4e0809b62b88d26e61e4e4#ae3a9d465424b3321c4e0809b62b88d26e61e4e4"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -6684,7 +6684,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.7.2"
-source = "git+https://github.com/S1nus/librustzcash.git?rev=3936d052035e66329f06665f891ebc2a3bc06b09#3936d052035e66329f06665f891ebc2a3bc06b09"
+source = "git+https://github.com/tachyon-zcash/librustzcash.git?rev=ae3a9d465424b3321c4e0809b62b88d26e61e4e4#ae3a9d465424b3321c4e0809b62b88d26e61e4e4"
 dependencies = [
  "core2",
  "document-features",
@@ -6722,22 +6722,6 @@ dependencies = [
 [[package]]
 name = "zcash_tachyon"
 version = "0.0.0"
-source = "git+https://github.com/tachyon-zcash/tachyon.git?rev=0d5785925a7e4e8190609ae0b3d9797b0dd2512a#0d5785925a7e4e8190609ae0b3d9797b0dd2512a"
-dependencies = [
- "bitvec",
- "blake2b_simd",
- "ff",
- "group",
- "pasta_curves",
- "proptest",
- "rand 0.8.5",
- "reddsa",
- "serde",
-]
-
-[[package]]
-name = "zcash_tachyon"
-version = "0.0.0"
 source = "git+https://github.com/tachyon-zcash/tachyon.git?rev=a441c0cba73c9accebac324abdbd28b2f9701dd5#a441c0cba73c9accebac324abdbd28b2f9701dd5"
 dependencies = [
  "blake2b_simd",
@@ -6747,12 +6731,13 @@ dependencies = [
  "pasta_curves",
  "rand_core 0.6.4",
  "reddsa",
+ "serde",
 ]
 
 [[package]]
 name = "zcash_transparent"
 version = "0.6.3"
-source = "git+https://github.com/S1nus/librustzcash.git?rev=3936d052035e66329f06665f891ebc2a3bc06b09#3936d052035e66329f06665f891ebc2a3bc06b09"
+source = "git+https://github.com/tachyon-zcash/librustzcash.git?rev=ae3a9d465424b3321c4e0809b62b88d26e61e4e4#ae3a9d465424b3321c4e0809b62b88d26e61e4e4"
 dependencies = [
  "bip32",
  "blake2b_simd",
@@ -6839,7 +6824,7 @@ dependencies = [
  "zcash_primitives",
  "zcash_protocol",
  "zcash_script",
- "zcash_tachyon 0.0.0 (git+https://github.com/tachyon-zcash/tachyon.git?rev=0d5785925a7e4e8190609ae0b3d9797b0dd2512a)",
+ "zcash_tachyon",
  "zcash_transparent",
  "zebra-test",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1550,7 +1550,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.2.2"
-source = "git+https://github.com/tachyon-zcash/librustzcash.git?rev=ae3a9d465424b3321c4e0809b62b88d26e61e4e4#ae3a9d465424b3321c4e0809b62b88d26e61e4e4"
+source = "git+https://github.com/tachyon-zcash/librustzcash.git?branch=main#ae3a9d465424b3321c4e0809b62b88d26e61e4e4"
 dependencies = [
  "blake2b_simd",
  "cc",
@@ -1597,7 +1597,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/tachyon-zcash/librustzcash.git?rev=ae3a9d465424b3321c4e0809b62b88d26e61e4e4#ae3a9d465424b3321c4e0809b62b88d26e61e4e4"
+source = "git+https://github.com/tachyon-zcash/librustzcash.git?branch=main#ae3a9d465424b3321c4e0809b62b88d26e61e4e4"
 dependencies = [
  "blake2b_simd",
 ]
@@ -6545,7 +6545,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.10.1"
-source = "git+https://github.com/tachyon-zcash/librustzcash.git?rev=ae3a9d465424b3321c4e0809b62b88d26e61e4e4#ae3a9d465424b3321c4e0809b62b88d26e61e4e4"
+source = "git+https://github.com/tachyon-zcash/librustzcash.git?branch=main#ae3a9d465424b3321c4e0809b62b88d26e61e4e4"
 dependencies = [
  "bech32",
  "bs58",
@@ -6558,7 +6558,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.3.0"
-source = "git+https://github.com/tachyon-zcash/librustzcash.git?rev=ae3a9d465424b3321c4e0809b62b88d26e61e4e4#ae3a9d465424b3321c4e0809b62b88d26e61e4e4"
+source = "git+https://github.com/tachyon-zcash/librustzcash.git?branch=main#ae3a9d465424b3321c4e0809b62b88d26e61e4e4"
 dependencies = [
  "core2",
  "hex",
@@ -6568,7 +6568,7 @@ dependencies = [
 [[package]]
 name = "zcash_history"
 version = "0.4.0"
-source = "git+https://github.com/tachyon-zcash/librustzcash.git?rev=ae3a9d465424b3321c4e0809b62b88d26e61e4e4#ae3a9d465424b3321c4e0809b62b88d26e61e4e4"
+source = "git+https://github.com/tachyon-zcash/librustzcash.git?branch=main#ae3a9d465424b3321c4e0809b62b88d26e61e4e4"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -6578,7 +6578,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.12.0"
-source = "git+https://github.com/tachyon-zcash/librustzcash.git?rev=ae3a9d465424b3321c4e0809b62b88d26e61e4e4#ae3a9d465424b3321c4e0809b62b88d26e61e4e4"
+source = "git+https://github.com/tachyon-zcash/librustzcash.git?branch=main#ae3a9d465424b3321c4e0809b62b88d26e61e4e4"
 dependencies = [
  "bech32",
  "blake2b_simd",
@@ -6618,7 +6618,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.26.4"
-source = "git+https://github.com/tachyon-zcash/librustzcash.git?rev=ae3a9d465424b3321c4e0809b62b88d26e61e4e4#ae3a9d465424b3321c4e0809b62b88d26e61e4e4"
+source = "git+https://github.com/tachyon-zcash/librustzcash.git?branch=main#ae3a9d465424b3321c4e0809b62b88d26e61e4e4"
 dependencies = [
  "bip32",
  "blake2b_simd",
@@ -6662,7 +6662,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.26.1"
-source = "git+https://github.com/tachyon-zcash/librustzcash.git?rev=ae3a9d465424b3321c4e0809b62b88d26e61e4e4#ae3a9d465424b3321c4e0809b62b88d26e61e4e4"
+source = "git+https://github.com/tachyon-zcash/librustzcash.git?branch=main#ae3a9d465424b3321c4e0809b62b88d26e61e4e4"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -6684,7 +6684,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.7.2"
-source = "git+https://github.com/tachyon-zcash/librustzcash.git?rev=ae3a9d465424b3321c4e0809b62b88d26e61e4e4#ae3a9d465424b3321c4e0809b62b88d26e61e4e4"
+source = "git+https://github.com/tachyon-zcash/librustzcash.git?branch=main#ae3a9d465424b3321c4e0809b62b88d26e61e4e4"
 dependencies = [
  "core2",
  "document-features",
@@ -6737,7 +6737,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.6.3"
-source = "git+https://github.com/tachyon-zcash/librustzcash.git?rev=ae3a9d465424b3321c4e0809b62b88d26e61e4e4#ae3a9d465424b3321c4e0809b62b88d26e61e4e4"
+source = "git+https://github.com/tachyon-zcash/librustzcash.git?branch=main#ae3a9d465424b3321c4e0809b62b88d26e61e4e4"
 dependencies = [
  "bip32",
  "blake2b_simd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1550,7 +1550,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.2.2"
-source = "git+https://github.com/tachyon-zcash/librustzcash.git?branch=main#79ef13ccaaf25d28a2b3fb356f2ef21185548e95"
+source = "git+https://github.com/S1nus/librustzcash.git?rev=3936d052035e66329f06665f891ebc2a3bc06b09#3936d052035e66329f06665f891ebc2a3bc06b09"
 dependencies = [
  "blake2b_simd",
  "cc",
@@ -1597,7 +1597,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/tachyon-zcash/librustzcash.git?branch=main#79ef13ccaaf25d28a2b3fb356f2ef21185548e95"
+source = "git+https://github.com/S1nus/librustzcash.git?rev=3936d052035e66329f06665f891ebc2a3bc06b09#3936d052035e66329f06665f891ebc2a3bc06b09"
 dependencies = [
  "blake2b_simd",
 ]
@@ -6545,7 +6545,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.10.1"
-source = "git+https://github.com/tachyon-zcash/librustzcash.git?branch=main#79ef13ccaaf25d28a2b3fb356f2ef21185548e95"
+source = "git+https://github.com/S1nus/librustzcash.git?rev=3936d052035e66329f06665f891ebc2a3bc06b09#3936d052035e66329f06665f891ebc2a3bc06b09"
 dependencies = [
  "bech32",
  "bs58",
@@ -6558,7 +6558,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.3.0"
-source = "git+https://github.com/tachyon-zcash/librustzcash.git?branch=main#79ef13ccaaf25d28a2b3fb356f2ef21185548e95"
+source = "git+https://github.com/S1nus/librustzcash.git?rev=3936d052035e66329f06665f891ebc2a3bc06b09#3936d052035e66329f06665f891ebc2a3bc06b09"
 dependencies = [
  "core2",
  "hex",
@@ -6568,7 +6568,7 @@ dependencies = [
 [[package]]
 name = "zcash_history"
 version = "0.4.0"
-source = "git+https://github.com/tachyon-zcash/librustzcash.git?branch=main#79ef13ccaaf25d28a2b3fb356f2ef21185548e95"
+source = "git+https://github.com/S1nus/librustzcash.git?rev=3936d052035e66329f06665f891ebc2a3bc06b09#3936d052035e66329f06665f891ebc2a3bc06b09"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -6578,7 +6578,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.12.0"
-source = "git+https://github.com/tachyon-zcash/librustzcash.git?branch=main#79ef13ccaaf25d28a2b3fb356f2ef21185548e95"
+source = "git+https://github.com/S1nus/librustzcash.git?rev=3936d052035e66329f06665f891ebc2a3bc06b09#3936d052035e66329f06665f891ebc2a3bc06b09"
 dependencies = [
  "bech32",
  "blake2b_simd",
@@ -6618,7 +6618,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.26.4"
-source = "git+https://github.com/tachyon-zcash/librustzcash.git?branch=main#79ef13ccaaf25d28a2b3fb356f2ef21185548e95"
+source = "git+https://github.com/S1nus/librustzcash.git?rev=3936d052035e66329f06665f891ebc2a3bc06b09#3936d052035e66329f06665f891ebc2a3bc06b09"
 dependencies = [
  "bip32",
  "blake2b_simd",
@@ -6638,6 +6638,7 @@ dependencies = [
  "memuse",
  "nonempty",
  "orchard",
+ "pasta_curves",
  "rand 0.8.5",
  "rand_core 0.6.4",
  "redjubjub",
@@ -6653,6 +6654,7 @@ dependencies = [
  "zcash_protocol",
  "zcash_script",
  "zcash_spec",
+ "zcash_tachyon 0.0.0 (git+https://github.com/tachyon-zcash/tachyon.git?rev=a441c0cba73c9accebac324abdbd28b2f9701dd5)",
  "zcash_transparent",
  "zip32",
 ]
@@ -6660,7 +6662,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.26.1"
-source = "git+https://github.com/tachyon-zcash/librustzcash.git?branch=main#79ef13ccaaf25d28a2b3fb356f2ef21185548e95"
+source = "git+https://github.com/S1nus/librustzcash.git?rev=3936d052035e66329f06665f891ebc2a3bc06b09#3936d052035e66329f06665f891ebc2a3bc06b09"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -6682,7 +6684,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.7.2"
-source = "git+https://github.com/tachyon-zcash/librustzcash.git?branch=main#79ef13ccaaf25d28a2b3fb356f2ef21185548e95"
+source = "git+https://github.com/S1nus/librustzcash.git?rev=3936d052035e66329f06665f891ebc2a3bc06b09#3936d052035e66329f06665f891ebc2a3bc06b09"
 dependencies = [
  "core2",
  "document-features",
@@ -6734,9 +6736,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "zcash_tachyon"
+version = "0.0.0"
+source = "git+https://github.com/tachyon-zcash/tachyon.git?rev=a441c0cba73c9accebac324abdbd28b2f9701dd5#a441c0cba73c9accebac324abdbd28b2f9701dd5"
+dependencies = [
+ "blake2b_simd",
+ "ff",
+ "group",
+ "lazy_static",
+ "pasta_curves",
+ "rand_core 0.6.4",
+ "reddsa",
+]
+
+[[package]]
 name = "zcash_transparent"
 version = "0.6.3"
-source = "git+https://github.com/tachyon-zcash/librustzcash.git?branch=main#79ef13ccaaf25d28a2b3fb356f2ef21185548e95"
+source = "git+https://github.com/S1nus/librustzcash.git?rev=3936d052035e66329f06665f891ebc2a3bc06b09#3936d052035e66329f06665f891ebc2a3bc06b09"
 dependencies = [
  "bip32",
  "blake2b_simd",
@@ -6823,7 +6839,7 @@ dependencies = [
  "zcash_primitives",
  "zcash_protocol",
  "zcash_script",
- "zcash_tachyon",
+ "zcash_tachyon 0.0.0 (git+https://github.com/tachyon-zcash/tachyon.git?rev=0d5785925a7e4e8190609ae0b3d9797b0dd2512a)",
  "zcash_transparent",
  "zebra-test",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,15 +24,15 @@ incrementalmerkletree = { version = "0.8.2", features = ["legacy-api"] }
 orchard = "0.12"
 zcash_tachyon = {git = "https://github.com/tachyon-zcash/tachyon.git", rev="0d5785925a7e4e8190609ae0b3d9797b0dd2512a"}
 sapling-crypto = "0.6"
-zcash_address = {git = "https://github.com/tachyon-zcash/librustzcash.git", branch = "main"}
-zcash_encoding = {git = "https://github.com/tachyon-zcash/librustzcash.git", branch = "main"}
-zcash_history = {git = "https://github.com/tachyon-zcash/librustzcash.git", branch = "main"}
-zcash_keys = {git = "https://github.com/tachyon-zcash/librustzcash.git", branch = "main"}
-zcash_primitives = {git = "https://github.com/tachyon-zcash/librustzcash.git", branch = "main"}
-zcash_proofs = {git = "https://github.com/tachyon-zcash/librustzcash.git", branch = "main"}
-zcash_transparent = {git = "https://github.com/tachyon-zcash/librustzcash.git", branch = "main"}
-zcash_protocol = {git = "https://github.com/tachyon-zcash/librustzcash.git", branch = "main"}
-equihash = {git = "https://github.com/tachyon-zcash/librustzcash.git", branch = "main"}
+zcash_address = {git = "https://github.com/S1nus/librustzcash.git", rev="3936d052035e66329f06665f891ebc2a3bc06b09"}
+zcash_encoding = {git = "https://github.com/S1nus/librustzcash.git", rev="3936d052035e66329f06665f891ebc2a3bc06b09"}
+zcash_history = {git = "https://github.com/S1nus/librustzcash.git", rev="3936d052035e66329f06665f891ebc2a3bc06b09"}
+zcash_keys = {git = "https://github.com/S1nus/librustzcash.git", rev="3936d052035e66329f06665f891ebc2a3bc06b09"}
+zcash_primitives = {git = "https://github.com/S1nus/librustzcash.git", rev="3936d052035e66329f06665f891ebc2a3bc06b09"}
+zcash_proofs = {git = "https://github.com/S1nus/librustzcash.git", rev="3936d052035e66329f06665f891ebc2a3bc06b09"}
+zcash_transparent = {git = "https://github.com/S1nus/librustzcash.git", rev="3936d052035e66329f06665f891ebc2a3bc06b09"}
+zcash_protocol = {git = "https://github.com/S1nus/librustzcash.git", rev="3936d052035e66329f06665f891ebc2a3bc06b09"}
+equihash = {git = "https://github.com/S1nus/librustzcash.git", rev="3936d052035e66329f06665f891ebc2a3bc06b09"}
 zip32 = "0.2"
 abscissa_core = "0.7"
 atty = "0.2.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,17 +22,17 @@ resolver = "2"
 [workspace.dependencies]
 incrementalmerkletree = { version = "0.8.2", features = ["legacy-api"] }
 orchard = "0.12"
-zcash_tachyon = {git = "https://github.com/tachyon-zcash/tachyon.git", rev="0d5785925a7e4e8190609ae0b3d9797b0dd2512a"}
+zcash_tachyon = { git = "https://github.com/tachyon-zcash/tachyon.git", rev = "a441c0cba73c9accebac324abdbd28b2f9701dd5", default-features = false }
 sapling-crypto = "0.6"
-zcash_address = {git = "https://github.com/S1nus/librustzcash.git", rev="3936d052035e66329f06665f891ebc2a3bc06b09"}
-zcash_encoding = {git = "https://github.com/S1nus/librustzcash.git", rev="3936d052035e66329f06665f891ebc2a3bc06b09"}
-zcash_history = {git = "https://github.com/S1nus/librustzcash.git", rev="3936d052035e66329f06665f891ebc2a3bc06b09"}
-zcash_keys = {git = "https://github.com/S1nus/librustzcash.git", rev="3936d052035e66329f06665f891ebc2a3bc06b09"}
-zcash_primitives = {git = "https://github.com/S1nus/librustzcash.git", rev="3936d052035e66329f06665f891ebc2a3bc06b09"}
-zcash_proofs = {git = "https://github.com/S1nus/librustzcash.git", rev="3936d052035e66329f06665f891ebc2a3bc06b09"}
-zcash_transparent = {git = "https://github.com/S1nus/librustzcash.git", rev="3936d052035e66329f06665f891ebc2a3bc06b09"}
-zcash_protocol = {git = "https://github.com/S1nus/librustzcash.git", rev="3936d052035e66329f06665f891ebc2a3bc06b09"}
-equihash = {git = "https://github.com/S1nus/librustzcash.git", rev="3936d052035e66329f06665f891ebc2a3bc06b09"}
+zcash_address = {git = "https://github.com/tachyon-zcash/librustzcash.git", rev="ae3a9d465424b3321c4e0809b62b88d26e61e4e4"}
+zcash_encoding = {git = "https://github.com/tachyon-zcash/librustzcash.git", rev="ae3a9d465424b3321c4e0809b62b88d26e61e4e4"}
+zcash_history = {git = "https://github.com/tachyon-zcash/librustzcash.git", rev="ae3a9d465424b3321c4e0809b62b88d26e61e4e4"}
+zcash_keys = {git = "https://github.com/tachyon-zcash/librustzcash.git", rev="ae3a9d465424b3321c4e0809b62b88d26e61e4e4"}
+zcash_primitives = {git = "https://github.com/tachyon-zcash/librustzcash.git", rev="ae3a9d465424b3321c4e0809b62b88d26e61e4e4"}
+zcash_proofs = {git = "https://github.com/tachyon-zcash/librustzcash.git", rev="ae3a9d465424b3321c4e0809b62b88d26e61e4e4"}
+zcash_transparent = {git = "https://github.com/tachyon-zcash/librustzcash.git", rev="ae3a9d465424b3321c4e0809b62b88d26e61e4e4"}
+zcash_protocol = {git = "https://github.com/tachyon-zcash/librustzcash.git", rev="ae3a9d465424b3321c4e0809b62b88d26e61e4e4"}
+equihash = {git = "https://github.com/tachyon-zcash/librustzcash.git", rev="ae3a9d465424b3321c4e0809b62b88d26e61e4e4"}
 zip32 = "0.2"
 abscissa_core = "0.7"
 atty = "0.2.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,15 +24,15 @@ incrementalmerkletree = { version = "0.8.2", features = ["legacy-api"] }
 orchard = "0.12"
 zcash_tachyon = {git = "https://github.com/tachyon-zcash/tachyon.git", rev="a441c0cba73c9accebac324abdbd28b2f9701dd5"}
 sapling-crypto = "0.6"
-zcash_address = {git = "https://github.com/tachyon-zcash/librustzcash.git", rev="ae3a9d465424b3321c4e0809b62b88d26e61e4e4"}
-zcash_encoding = {git = "https://github.com/tachyon-zcash/librustzcash.git", rev="ae3a9d465424b3321c4e0809b62b88d26e61e4e4"}
-zcash_history = {git = "https://github.com/tachyon-zcash/librustzcash.git", rev="ae3a9d465424b3321c4e0809b62b88d26e61e4e4"}
-zcash_keys = {git = "https://github.com/tachyon-zcash/librustzcash.git", rev="ae3a9d465424b3321c4e0809b62b88d26e61e4e4"}
-zcash_primitives = {git = "https://github.com/tachyon-zcash/librustzcash.git", rev="ae3a9d465424b3321c4e0809b62b88d26e61e4e4"}
-zcash_proofs = {git = "https://github.com/tachyon-zcash/librustzcash.git", rev="ae3a9d465424b3321c4e0809b62b88d26e61e4e4"}
-zcash_transparent = {git = "https://github.com/tachyon-zcash/librustzcash.git", rev="ae3a9d465424b3321c4e0809b62b88d26e61e4e4"}
-zcash_protocol = {git = "https://github.com/tachyon-zcash/librustzcash.git", rev="ae3a9d465424b3321c4e0809b62b88d26e61e4e4"}
-equihash = {git = "https://github.com/tachyon-zcash/librustzcash.git", rev="ae3a9d465424b3321c4e0809b62b88d26e61e4e4"}
+zcash_address = {git = "https://github.com/tachyon-zcash/librustzcash.git", branch = "main"}
+zcash_encoding = {git = "https://github.com/tachyon-zcash/librustzcash.git", branch = "main"}
+zcash_history = {git = "https://github.com/tachyon-zcash/librustzcash.git", branch = "main"}
+zcash_keys = {git = "https://github.com/tachyon-zcash/librustzcash.git", branch = "main"}
+zcash_primitives = {git = "https://github.com/tachyon-zcash/librustzcash.git", branch = "main"}
+zcash_proofs = {git = "https://github.com/tachyon-zcash/librustzcash.git", branch = "main"}
+zcash_transparent = {git = "https://github.com/tachyon-zcash/librustzcash.git", branch = "main"}
+zcash_protocol = {git = "https://github.com/tachyon-zcash/librustzcash.git", branch = "main"}
+equihash = {git = "https://github.com/tachyon-zcash/librustzcash.git", branch = "main"}
 zip32 = "0.2"
 abscissa_core = "0.7"
 atty = "0.2.14"

--- a/zebra-chain/src/transaction/arbitrary.rs
+++ b/zebra-chain/src/transaction/arbitrary.rs
@@ -1220,7 +1220,7 @@ fn arb_tachyon_action() -> BoxedStrategy<zcash_tachyon::Action> {
 #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
 fn arb_tachyon_stamp() -> BoxedStrategy<zcash_tachyon::Stamp> {
     (
-        vec(arb_tachygram(), 1..MAX_ARBITRARY_ITEMS),
+        vec(arb_tachygram(), 0..MAX_ARBITRARY_ITEMS),
         arb_anchor(),
     )
         .prop_map(|(tachygrams, anchor)| zcash_tachyon::Stamp {
@@ -1259,7 +1259,7 @@ fn arb_anchor() -> BoxedStrategy<zcash_tachyon::Anchor> {
 #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
 fn arb_tachyon_bundle() -> BoxedStrategy<zcash_tachyon::Bundle<Option<zcash_tachyon::Stamp>>> {
     (
-        vec(arb_tachyon_action(), 1..MAX_ARBITRARY_ITEMS),
+        vec(arb_tachyon_action(), 0..MAX_ARBITRARY_ITEMS),
         any::<i64>(),
         vec(any::<u8>(), 64),
         option::of(arb_tachyon_stamp()),

--- a/zebra-chain/src/transaction/arbitrary.rs
+++ b/zebra-chain/src/transaction/arbitrary.rs
@@ -6,6 +6,15 @@ use chrono::{TimeZone, Utc};
 use proptest::{array, collection::vec, option, prelude::*, test_runner::TestRunner};
 use reddsa::{orchard::Binding, Signature};
 
+#[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
+use group::prime::PrimeCurveAffine;
+#[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
+use group::ff::{FromUniformBytes, PrimeField};
+#[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
+use halo2::pasta::pallas;
+#[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
+use reddsa::{orchard::SpendAuth, SigningKey, VerificationKey};
+
 use crate::{
     amount::{self, Amount, NegativeAllowed, NonNegative},
     at_least_one,
@@ -174,6 +183,64 @@ impl Transaction {
                             None
                         } else {
                             orchard_shielded_data
+                        },
+                    }
+                },
+            )
+            .boxed()
+    }
+
+    /// Generate a proptest strategy for V6 Transactions
+    #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
+    pub fn v6_strategy(ledger_state: LedgerState) -> BoxedStrategy<Self> {
+        (
+            NetworkUpgrade::branch_id_strategy(),
+            any::<LockTime>(),
+            any::<block::Height>(),
+            any::<Amount<NonNegative>>(),
+            transparent::Input::vec_strategy(&ledger_state, MAX_ARBITRARY_ITEMS),
+            vec(any::<transparent::Output>(), 0..MAX_ARBITRARY_ITEMS),
+            option::of(any::<sapling::ShieldedData<sapling::SharedAnchor>>()),
+            option::of(any::<orchard::ShieldedData>()),
+            option::of(arb_tachyon_bundle()),
+        )
+            .prop_map(
+                move |(
+                    network_upgrade,
+                    lock_time,
+                    expiry_height,
+                    zip233_amount,
+                    inputs,
+                    outputs,
+                    sapling_shielded_data,
+                    orchard_shielded_data,
+                    tachyon_shielded_data,
+                )| {
+                    Transaction::V6 {
+                        network_upgrade: if ledger_state.transaction_has_valid_network_upgrade() {
+                            ledger_state.network_upgrade()
+                        } else {
+                            network_upgrade
+                        },
+                        lock_time,
+                        expiry_height,
+                        zip233_amount,
+                        inputs,
+                        outputs,
+                        sapling_shielded_data: if ledger_state.height.is_min() {
+                            None
+                        } else {
+                            sapling_shielded_data
+                        },
+                        orchard_shielded_data: if ledger_state.height.is_min() {
+                            None
+                        } else {
+                            orchard_shielded_data
+                        },
+                        tachyon_shielded_data: if ledger_state.height.is_min() {
+                            None
+                        } else {
+                            tachyon_shielded_data
                         },
                     }
                 },
@@ -765,6 +832,8 @@ impl Arbitrary for Transaction {
             Some(3) => return Self::v3_strategy(ledger_state),
             Some(4) => return Self::v4_strategy(ledger_state),
             Some(5) => return Self::v5_strategy(ledger_state),
+            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
+            Some(6) => return Self::v6_strategy(ledger_state),
             Some(_) => unreachable!("invalid transaction version in override"),
             None => {}
         }
@@ -778,12 +847,30 @@ impl Arbitrary for Transaction {
             NetworkUpgrade::Blossom | NetworkUpgrade::Heartwood | NetworkUpgrade::Canopy => {
                 Self::v4_strategy(ledger_state)
             }
+            #[cfg(not(all(zcash_unstable = "nu7", feature = "tx_v6")))]
             NetworkUpgrade::Nu5
             | NetworkUpgrade::Nu6
             | NetworkUpgrade::Nu6_1
             | NetworkUpgrade::Nu7 => prop_oneof![
                 Self::v4_strategy(ledger_state.clone()),
                 Self::v5_strategy(ledger_state)
+            ]
+            .boxed(),
+
+            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
+            NetworkUpgrade::Nu5
+            | NetworkUpgrade::Nu6
+            | NetworkUpgrade::Nu6_1 => prop_oneof![
+                Self::v4_strategy(ledger_state.clone()),
+                Self::v5_strategy(ledger_state)
+            ]
+            .boxed(),
+
+            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
+            NetworkUpgrade::Nu7 => prop_oneof![
+                Self::v4_strategy(ledger_state.clone()),
+                Self::v5_strategy(ledger_state.clone()),
+                Self::v6_strategy(ledger_state)
             ]
             .boxed(),
 
@@ -1093,4 +1180,100 @@ pub fn insert_fake_orchard_shielded_data(
         }
         _ => panic!("Fake V5 transaction is not V5"),
     }
+}
+
+// Tachyon proptest strategies
+
+/// Generate an arbitrary tachyon Action.
+#[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
+fn arb_tachyon_action() -> BoxedStrategy<zcash_tachyon::Action> {
+    (
+        vec(any::<u8>(), 64),  // for rk derivation
+        vec(any::<u8>(), 64),  // for action sig
+    )
+        .prop_map(|(rk_seed, sig_bytes)| {
+            let rk_seed: [u8; 64] = rk_seed.try_into().expect("vec is the correct length");
+            let sk_scalar = pallas::Scalar::from_uniform_bytes(&rk_seed);
+            let sk_bytes = sk_scalar.to_repr();
+            let sk = SigningKey::<SpendAuth>::try_from(sk_bytes).unwrap();
+            let pk = VerificationKey::<SpendAuth>::from(&sk);
+            let rk = zcash_tachyon::keys::public::ActionVerificationKey::try_from(
+                <[u8; 32]>::from(pk),
+            )
+            .unwrap();
+
+            let mut sig_arr = [0u8; 64];
+            sig_arr.copy_from_slice(&sig_bytes);
+
+            zcash_tachyon::Action {
+                cv: zcash_tachyon::value::Commitment::from(
+                    pasta_curves::EpAffine::identity(),
+                ),
+                rk,
+                sig: zcash_tachyon::action::Signature::from(sig_arr),
+            }
+        })
+        .boxed()
+}
+
+/// Generate an arbitrary tachyon Stamp.
+#[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
+fn arb_tachyon_stamp() -> BoxedStrategy<zcash_tachyon::Stamp> {
+    (
+        vec(arb_tachygram(), 1..MAX_ARBITRARY_ITEMS),
+        arb_anchor(),
+    )
+        .prop_map(|(tachygrams, anchor)| zcash_tachyon::Stamp {
+            tachygrams,
+            anchor,
+            proof: zcash_tachyon::Proof,
+        })
+        .boxed()
+}
+
+/// Generate an arbitrary tachyon Tachygram.
+#[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
+fn arb_tachygram() -> BoxedStrategy<zcash_tachyon::Tachygram> {
+    vec(any::<u8>(), 64)
+        .prop_map(|bytes| {
+            let bytes: [u8; 64] = bytes.try_into().expect("vec is the correct length");
+            let fp = pasta_curves::Fp::from_uniform_bytes(&bytes);
+            zcash_tachyon::Tachygram::from(fp)
+        })
+        .boxed()
+}
+
+/// Generate an arbitrary tachyon Anchor.
+#[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
+fn arb_anchor() -> BoxedStrategy<zcash_tachyon::Anchor> {
+    vec(any::<u8>(), 64)
+        .prop_map(|bytes| {
+            let bytes: [u8; 64] = bytes.try_into().expect("vec is the correct length");
+            let fp = pasta_curves::Fp::from_uniform_bytes(&bytes);
+            zcash_tachyon::Anchor::from(fp)
+        })
+        .boxed()
+}
+
+/// Generate an arbitrary tachyon Bundle with optional Stamp.
+#[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
+fn arb_tachyon_bundle() -> BoxedStrategy<zcash_tachyon::Bundle<Option<zcash_tachyon::Stamp>>> {
+    (
+        vec(arb_tachyon_action(), 1..MAX_ARBITRARY_ITEMS),
+        any::<i64>(),
+        vec(any::<u8>(), 64),
+        option::of(arb_tachyon_stamp()),
+    )
+        .prop_map(|(actions, value_balance, binding_sig_bytes, stamp)| {
+            let mut sig_arr = [0u8; 64];
+            sig_arr.copy_from_slice(&binding_sig_bytes);
+
+            zcash_tachyon::Bundle {
+                actions,
+                value_balance,
+                binding_sig: zcash_tachyon::bundle::Signature::from(sig_arr),
+                stamp,
+            }
+        })
+        .boxed()
 }

--- a/zebra-chain/src/transaction/tests/prop.rs
+++ b/zebra-chain/src/transaction/tests/prop.rs
@@ -121,7 +121,15 @@ fn arbitrary_transaction_version_strategy() -> Result<()> {
     let _init_guard = zebra_test::init();
 
     // Update with new transaction versions as needed
-    let strategy = (1..5u32)
+    #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
+    let strategy = (1..=6u32)
+        .prop_flat_map(|transaction_version| {
+            LedgerState::coinbase_strategy(None, transaction_version, false)
+        })
+        .prop_flat_map(|ledger_state| Transaction::vec_strategy(ledger_state, MAX_ARBITRARY_ITEMS));
+
+    #[cfg(not(all(zcash_unstable = "nu7", feature = "tx_v6")))]
+    let strategy = (1..=5u32)
         .prop_flat_map(|transaction_version| {
             LedgerState::coinbase_strategy(None, transaction_version, false)
         })


### PR DESCRIPTION
- proptest strategies for tachyon bundles
- fix what seems to be a longstanding bug where v5 transactions were excluded from `arbitrary_transaction_version_strategy`
- add v6 transactions to `arbitrary_transaction_version_strategy`